### PR TITLE
Tab-delimited parser for DataTableDumper

### DIFF
--- a/src/CrossCutting.Common.Testing/TestHelpers.cs
+++ b/src/CrossCutting.Common.Testing/TestHelpers.cs
@@ -1,9 +1,7 @@
 ﻿using FluentAssertions;
 using Moq;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 
@@ -152,20 +150,6 @@ namespace CrossCutting.Common.Testing
                                 : provider?.GetService(parameterInfo.ParameterType)
                         ).ToArray()
             );
-        }
-
-        public static string[] GetLines(this string instance)
-        {
-            var result = new List<string>();
-            using (var reader = new StringReader(instance))
-            {
-                string line;
-                while ((line = reader.ReadLine()) != null)
-                {
-                    result.Add(line);
-                }
-            }
-            return result.ToArray();
         }
     }
 }

--- a/src/CrossCutting.Common/Extensions/StringExtensions.cs
+++ b/src/CrossCutting.Common/Extensions/StringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace CrossCutting.Common.Extensions
@@ -166,5 +167,19 @@ namespace CrossCutting.Common.Extensions
         /// <returns></returns>
         public static bool EndsWithAny(this string instance, StringComparison comparisonType, IEnumerable<string> values)
             => values.Any(v => instance.EndsWith(v, comparisonType));
+
+        public static string[] GetLines(this string instance)
+        {
+            var result = new List<string>();
+            using (var reader = new StringReader(instance))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    result.Add(line);
+                }
+            }
+            return result.ToArray();
+        }
     }
 }

--- a/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
+++ b/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CrossCutting.Common.Testing\CrossCutting.Common.Testing.csproj" />
+    <ProjectReference Include="..\CrossCutting.Common\CrossCutting.Common.csproj" />
     <ProjectReference Include="..\CrossCutting.DataTableDumper\CrossCutting.DataTableDumper.csproj" />
   </ItemGroup>
 

--- a/src/CrossCutting.DataTableDumper.Tests/DataTableDumperTests.cs
+++ b/src/CrossCutting.DataTableDumper.Tests/DataTableDumperTests.cs
@@ -1,4 +1,4 @@
-using CrossCutting.Common.Testing;
+using CrossCutting.Common.Extensions;
 using CrossCutting.DataTableDumper.Default;
 using FluentAssertions;
 using Xunit;
@@ -22,11 +22,42 @@ namespace CrossCutting.DataTableDumper.Tests
             var actual = sut.Dump(input);
 
             // Assert
-            var lines = TestHelpers.GetLines(actual);
+            var lines = actual.GetLines();
             lines.Should().HaveCount(3);
             lines.Should().HaveElementAt(0, "| Name                        | Age |");
             lines.Should().HaveElementAt(1, "| Person A                    | 42  |");
             lines.Should().HaveElementAt(2, "| Person B with a longer name | 8   |");
+        }
+
+        [Fact]
+        public void Can_Dump_ExcelTable()
+        {
+            // Arrange
+            var input = @"Kolom A	Kolom B	Kolom C
+A	1	z
+B	2	y
+C	3	x
+D	4	w
+E	5	v
+F	6	u"; //copied directly from Excel 8-)
+
+            var result = TabDelimited.Parser.Parse(input);
+            var sut = result.DataTableDumper;
+            var list = result.List;
+
+            // Act
+            var actual = sut.Dump(list);
+
+            // Assert
+            var lines = actual.GetLines();
+            lines.Should().HaveCount(7);
+            lines.Should().HaveElementAt(0, "| Kolom A | Kolom B | Kolom C |");
+            lines.Should().HaveElementAt(1, "| A       | 1       | z       |");
+            lines.Should().HaveElementAt(2, "| B       | 2       | y       |");
+            lines.Should().HaveElementAt(3, "| C       | 3       | x       |");
+            lines.Should().HaveElementAt(4, "| D       | 4       | w       |");
+            lines.Should().HaveElementAt(5, "| E       | 5       | v       |");
+            lines.Should().HaveElementAt(6, "| F       | 6       | u       |");
         }
 
         private class MyClass

--- a/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
+++ b/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\CrossCutting.Common\CrossCutting.Common.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Added tab-delimited parser to DataTableDumper, so you can easily convert Excel data directly to a data table that can be used with SpecFlow, for example. To accomplish this, I had to moved the GetLines extension method to CrossCutting.Common. (which is a better place than a test helper class, anyway...)