### PR TITLE
ReadOnlyValueCollection

### DIFF
--- a/.sonarlint/CrossCutting.slconfig
+++ b/.sonarlint/CrossCutting.slconfig
@@ -9,7 +9,7 @@
   "Profiles": {
     "CSharp": {
       "ProfileKey": "AXhZfo6en_M4LyoxHL-X",
-      "ProfileTimestamp": "2021-11-22T10:44:23Z"
+      "ProfileTimestamp": "2022-03-31T10:15:41Z"
     }
   }
 }

--- a/.sonarlint/pauldeen79_crosscutting/CSharp/SonarLint.xml
+++ b/.sonarlint/pauldeen79_crosscutting/CSharp/SonarLint.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<AnalysisInput xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<AnalysisInput xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Settings>
     <Setting>
       <Key>sonar.cs.analyzeGeneratedCode</Key>

--- a/.sonarlint/pauldeen79_crosscuttingcsharp.ruleset
+++ b/.sonarlint/pauldeen79_crosscuttingcsharp.ruleset
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SonarQube - CrossCutting Sonar way" Description="This rule set was automatically generated from SonarQube https://sonarcloud.io/profiles/show?key=AXhZfo6en_M4LyoxHL-X" ToolsVersion="14.0">
+<RuleSet xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="SonarQube - CrossCutting Sonar way" Description="This rule set was automatically generated from SonarQube https://sonarcloud.io/profiles/show?key=AXhZfo6en_M4LyoxHL-X" ToolsVersion="14.0">
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <Rule Id="S100" Action="None" />
     <Rule Id="S1006" Action="Warning" />
@@ -101,6 +101,7 @@
     <Rule Id="S2201" Action="Warning" />
     <Rule Id="S2219" Action="Info" />
     <Rule Id="S2221" Action="None" />
+    <Rule Id="S2222" Action="Warning" />
     <Rule Id="S2223" Action="Warning" />
     <Rule Id="S2225" Action="Warning" />
     <Rule Id="S2228" Action="None" />
@@ -360,6 +361,7 @@
     <Rule Id="S5547" Action="Warning" />
     <Rule Id="S5659" Action="Warning" />
     <Rule Id="S5773" Action="Warning" />
+    <Rule Id="S6354" Action="None" />
     <Rule Id="S818" Action="Info" />
     <Rule Id="S881" Action="None" />
     <Rule Id="S907" Action="Warning" />

--- a/src/CrossCutting.Common.Testing/CrossCutting.Common.Testing.csproj
+++ b/src/CrossCutting.Common.Testing/CrossCutting.Common.Testing.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
+    <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>
 
 </Project>

--- a/src/CrossCutting.Common.Testing/CrossCutting.Common.Testing.csproj
+++ b/src/CrossCutting.Common.Testing/CrossCutting.Common.Testing.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Moq" Version="4.18.1" />
   </ItemGroup>
 
 </Project>

--- a/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
+++ b/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
+++ b/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CrossCutting.Common.Tests/ReadOnlyValueCollectionTests.cs
+++ b/src/CrossCutting.Common.Tests/ReadOnlyValueCollectionTests.cs
@@ -1,0 +1,242 @@
+﻿namespace CrossCutting.Common.Tests;
+
+public class ReadOnlyValueCollectionTests
+{
+    [Fact]
+    public void Can_Construct_Empty_ReadOnlyValueCollection_With_Default_EqualityComparer()
+    {
+        // Act
+        var actual = new ReadOnlyValueCollection<string>();
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Can_Construct_Empty_ReadOnlyValueCollection_With_Custom_EqualityComparer()
+    {
+        // Arrange
+        var equalityComparerMock = new Mock<IEqualityComparer<string>>();
+
+        // Act
+        var actual = new ReadOnlyValueCollection<string>(equalityComparerMock.Object);
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Can_Construct_Prefilled_ReadOnlyValueCollection_With_Default_EqualityComparer()
+    {
+        // Act
+        var actual = new ReadOnlyValueCollection<string>(new[] { "a", "b", "c" });
+
+        // Assert
+        actual.Should().BeEquivalentTo(new[] { "a", "b", "c" });
+    }
+
+    [Fact]
+    public void Can_Construct_Prefilled_ReadOnlyValueCollection_With_Custom_EqualityComparer()
+    {
+        // Arrange
+        var equalityComparerMock = new Mock<IEqualityComparer<string>>();
+        equalityComparerMock.Setup(x => x.Equals(It.IsAny<string>(), It.IsAny<string>()))
+                            .Returns<string, string>((x, y) => x.ToUpperInvariant() == y.ToUpperInvariant());
+
+        // Act
+        var actual = new ReadOnlyValueCollection<string>(new[] { "a", "b", "c" }, equalityComparerMock.Object);
+
+        // Assert
+        actual.Should().BeEquivalentTo(new[] { "a", "b", "c" });
+    }
+
+    [Fact]
+    public void Can_Compare_Two_Value_Equal_ReadOnlyValueCollections_With_Default_EqualityComparer()
+    {
+        // Arrange
+        var value1 = new ReadOnlyValueCollection<string>(new[] { "a", "b", "c" });
+        var value2 = new ReadOnlyValueCollection<string>(new[] { "a", "b", "c" });
+
+        // Act
+        var actual = value1.Equals(value2);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Can_Compare_Two_Different_ReadOnlyValueCollections_With_Default_EqualityComparer_1()
+    {
+        // Arrange
+        var value1 = new ReadOnlyValueCollection<string>(new[] { "a", "b", "c" });
+        var value2 = new ReadOnlyValueCollection<string>(new[] { "a", "b" });
+
+        // Act
+        var actual = value1.Equals(value2);
+
+        // Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Can_Compare_Two_Different_ReadOnlyValueCollections_With_Default_EqualityComparer_2()
+    {
+        // Arrange
+        var value1 = new ReadOnlyValueCollection<string>(new[] { "a", "b" });
+        var value2 = new ReadOnlyValueCollection<string>(new[] { "a", "b", "c" });
+
+        // Act
+        var actual = value1.Equals(value2);
+
+        // Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Can_Compare_Two_ReadOnlyValueCollections_With_Custom_EqualityComparer()
+    {
+        // Arrange
+        var equalityComparerMock = new Mock<IEqualityComparer<string>>();
+        equalityComparerMock.Setup(x => x.Equals(It.IsAny<string>(), It.IsAny<string>()))
+                            .Returns<string, string>((x, y) => x.ToUpperInvariant() == y.ToUpperInvariant());
+        var value1 = new ReadOnlyValueCollection<string>(new[] { "a", "b", "C" }, equalityComparerMock.Object);
+        var value2 = new ReadOnlyValueCollection<string>(new[] { "A", "b", "c" }, equalityComparerMock.Object);
+
+        // Act
+        var actual = value1.Equals(value2);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_Returns_False_When_Other_Is_Null()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<string>(new[] { "a", "b", "C" });
+
+        // Act
+        var actual = value.Equals(null);
+
+        // Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_Returns_True_On_Same_Reference()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<string>(new[] { "a", "b", "C" });
+
+        // Act
+        var actual = value.Equals(value);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_Object_Two_ReadOnlyValueCollections_Returns_True_When_Value_Equal()
+    {
+        // Arrange
+        var value1 = new ReadOnlyValueCollection<string>(new[] { "a", "b", "c" });
+        var value2 = new ReadOnlyValueCollection<string>(new[] { "a", "b", "c" });
+
+        // Act
+        var actual = value1.Equals((object)value2);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_Object_Returns_False_When_Other_Is_Null()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<string>(new[] { "a", "b", "C" });
+
+        // Act
+        var actual = value.Equals((object?)null);
+
+        // Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_Object_Returns_True_On_Same_Reference()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<string>(new[] { "a", "b", "C" });
+
+        // Act
+        var actual = value.Equals((object)value);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ToString_Gives_Correct_Result_On_Null_Value()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<string?>(new string?[] { null, null });
+
+        // Act
+        var actual = value.ToString();
+
+        // Assert
+        actual.Should().Be("[∅, ∅]");
+    }
+
+    [Fact]
+    public void ToString_Gives_Correct_Result_On_Bool_Value()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<bool>(new[] { true, false });
+
+        // Act
+        var actual = value.ToString();
+
+        // Assert
+        actual.Should().Be("[true, false]");
+    }
+
+    [Fact]
+    public void ToString_Gives_Correct_Result_On_String_Value()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<string>(new[] { "a", "b" });
+
+        // Act
+        var actual = value.ToString();
+
+        // Assert
+        actual.Should().Be(@"[""a"", ""b""]");
+    }
+
+    [Fact]
+    public void ToString_Gives_Correct_Result_On_Char_Value()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<char>(new[] { 'a', 'b' });
+
+        // Act
+        var actual = value.ToString();
+
+        // Assert
+        actual.Should().Be("['a', 'b']");
+    }
+
+    [Fact]
+    public void ToString_Gives_Correct_Result_On_DateTime_Value()
+    {
+        // Arrange
+        var value = new ReadOnlyValueCollection<DateTime>(new[] { new DateTime(2020, 2, 1) });
+
+        // Act
+        var actual = value.ToString(null, CultureInfo.InvariantCulture);
+
+        // Assert
+        actual.Should().Be("[2020-02-01T00:00:00.0000000]");
+    }
+}

--- a/src/CrossCutting.Common/ReadOnlyValueCollection.cs
+++ b/src/CrossCutting.Common/ReadOnlyValueCollection.cs
@@ -1,0 +1,69 @@
+﻿namespace CrossCutting.Common;
+
+public sealed class ReadOnlyValueCollection<T> : ReadOnlyCollection<T>, IEquatable<ReadOnlyValueCollection<T>>, IFormattable
+{
+    private readonly IEqualityComparer<T> _equalityComparer;
+
+    public ReadOnlyValueCollection() : this(Enumerable.Empty<T>())
+    {
+    }
+
+    public ReadOnlyValueCollection(IEqualityComparer<T>? equalityComparer) : this(Enumerable.Empty<T>(), equalityComparer)
+    {
+    }
+
+    public ReadOnlyValueCollection(IEnumerable<T> list, IEqualityComparer<T>? equalityComparer = null) : base(list.ToList())
+        => _equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
+
+    public bool Equals(ReadOnlyValueCollection<T>? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        using var enumerator1 = GetEnumerator();
+        using var enumerator2 = other.GetEnumerator();
+
+        while (enumerator1.MoveNext())
+        {
+            if (!enumerator2.MoveNext() || !(_equalityComparer!).Equals(enumerator1.Current, enumerator2.Current))
+            {
+                return false;
+            }
+        }
+
+        return !enumerator2.MoveNext(); //both enumerations reached the end
+    }
+
+    public override bool Equals(object? obj)
+        => obj is { } && (ReferenceEquals(this, obj) || obj is ReadOnlyValueCollection<T> coll && Equals(coll));
+
+    public override int GetHashCode()
+        => unchecked(Items.Aggregate(0,
+            (current, element) => (current * 397) ^ (element is null ? 0 : _equalityComparer.GetHashCode(element))
+        ));
+
+    public string ToString(string? format, IFormatProvider? formatProvider)
+        => "[" + string.Join(", ", this.Select(e => FormatValue(e, formatProvider))) + "]";
+
+    public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
+
+    private static string? FormatValue(object? value, IFormatProvider? formatProvider)
+        => value switch
+        {
+            null => "∅",
+            bool b => b ? "true" : "false",
+            string s => $"\"{s}\"",
+            char c => $"\'{c}\'",
+            DateTime dt => dt.ToString("o", formatProvider),
+            IFormattable @if => @if.ToString(null, formatProvider),
+            IEnumerable ie => "[" + string.Join(", ", ie.Cast<object>().Select(e => FormatValue(e, formatProvider))) + "]",
+            _ => value.ToString()
+        };
+}

--- a/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
+++ b/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
+++ b/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
+++ b/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
@@ -8,15 +8,15 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
+++ b/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
+++ b/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.1" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
+++ b/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
@@ -8,16 +8,16 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
+++ b/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
+++ b/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">

--- a/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
+++ b/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">

--- a/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
+++ b/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
+++ b/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
+++ b/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
New implementation of a value collection, that is read-only. Useful in DDD scenarios where you don't want the state of the collection to change.