### PR TITLE
Named string format

### DIFF
--- a/src/CrossCutting.Common.Tests/NamedStringTests.cs
+++ b/src/CrossCutting.Common.Tests/NamedStringTests.cs
@@ -1,0 +1,43 @@
+﻿namespace CrossCutting.Common.Tests;
+
+public class NamedStringTests
+{
+    [Fact]
+    public void Can_Replace_Some_Tokens_Using_Format_Function()
+    {
+        // Arrange
+        const string Template = "Hello {Name}, you are {Age} years old. How do you feel?";
+
+        // Act
+        var result = NamedString.Format(Template, new { Name = "John Doe", Age = 43 });
+
+        // Assert
+        result.Should().Be("Hello John Doe, you are 43 years old. How do you feel?");
+    }
+
+    [Fact]
+    public void Can_Replace_Tokens_Case_Insensitive_Using_Format_Function()
+    {
+        // Arrange
+        const string Template = "Hello {NAME}, you are {AGE} years old. How do you feel?";
+
+        // Act
+        var result = NamedString.Format(Template, new { Name = "John Doe", Age = 43 }, ignoreCase: true);
+
+        // Assert
+        result.Should().Be("Hello John Doe, you are 43 years old. How do you feel?");
+    }
+
+    [Fact]
+    public void By_Default_Format_Function_Is_Case_Sensitive()
+    {
+        // Arrange
+        const string Template = "Hello {NAME}, you are {AGE} years old. How do you feel?";
+
+        // Act
+        var result = NamedString.Format(Template, new { Name = "John Doe", Age = 43 });
+
+        // Assert
+        result.Should().Be(Template); // no replacements were made
+    }
+}

--- a/src/CrossCutting.Common/NamedString.cs
+++ b/src/CrossCutting.Common/NamedString.cs
@@ -6,14 +6,14 @@ public static class NamedString
         => Format(template, parameters, false);
 
     public static string Format(string template, object parameters, bool ignoreCase)
-    {
-        var parametersDictionary = parameters.ToExpandoObject() as IDictionary<string, object>;
+        => parameters.ToExpandoObject().Aggregate
+        (
+            template,
+            (previous, item) => Regex.Replace(previous, $"{{{item.Key}}}", item.Value.ToStringWithDefault(), CreateRegExOptions(ignoreCase))
+        );
 
-        foreach (var item in parametersDictionary)
-        {
-            template = Regex.Replace(template, $"{{{item.Key}}}", item.Value.ToStringWithDefault(), ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None);
-        }
-
-        return template;
-    }
+    private static RegexOptions CreateRegExOptions(bool ignoreCase)
+        => ignoreCase
+            ? RegexOptions.IgnoreCase
+            : RegexOptions.None;
 }

--- a/src/CrossCutting.Common/NamedString.cs
+++ b/src/CrossCutting.Common/NamedString.cs
@@ -1,0 +1,19 @@
+﻿namespace CrossCutting.Common;
+
+public static class NamedString
+{
+    public static string Format(string template, object parameters)
+        => Format(template, parameters, false);
+
+    public static string Format(string template, object parameters, bool ignoreCase)
+    {
+        var parametersDictionary = parameters.ToExpandoObject() as IDictionary<string, object>;
+
+        foreach (var item in parametersDictionary)
+        {
+            template = Regex.Replace(template, $"{{{item.Key}}}", item.Value.ToStringWithDefault(), ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None);
+        }
+
+        return template;
+    }
+}


### PR DESCRIPTION
Added a nice, small utility class, which can replace this:

string.Format("Hello {0}, how are you?", "John Doe");

with this:

NamedString.Format("Hello {Name}, how are you?", new { Name = "John Doe" });