### PR TITLE
ObjectDumper IFormattable

### DIFF
--- a/.sonarlint/CrossCutting.slconfig
+++ b/.sonarlint/CrossCutting.slconfig
@@ -9,7 +9,11 @@
   "Profiles": {
     "CSharp": {
       "ProfileKey": "AXhZfo6en_M4LyoxHL-X",
-      "ProfileTimestamp": "2022-07-05T10:19:10Z"
+      "ProfileTimestamp": "2023-03-30T08:45:39Z"
+    },
+    "Secrets": {
+      "ProfileKey": "AYXoTKjH9Ao2yLWbNFAw",
+      "ProfileTimestamp": "2023-01-25T09:40:14Z"
     }
   }
 }

--- a/.sonarlint/pauldeen79_crosscutting_secrets_settings.json
+++ b/.sonarlint/pauldeen79_crosscutting_secrets_settings.json
@@ -1,0 +1,32 @@
+{
+  "sonarlint.rules": {
+    "secrets:S6338": {
+      "level": "On",
+      "severity": "Blocker"
+    },
+    "secrets:S6337": {
+      "level": "On",
+      "severity": "Blocker"
+    },
+    "secrets:S6290": {
+      "level": "On",
+      "severity": "Blocker"
+    },
+    "secrets:S6334": {
+      "level": "On",
+      "severity": "Blocker"
+    },
+    "secrets:S6336": {
+      "level": "On",
+      "severity": "Blocker"
+    },
+    "secrets:S6335": {
+      "level": "On",
+      "severity": "Blocker"
+    },
+    "secrets:S6292": {
+      "level": "On",
+      "severity": "Blocker"
+    }
+  }
+}

--- a/.sonarlint/pauldeen79_crosscuttingcsharp.ruleset
+++ b/.sonarlint/pauldeen79_crosscuttingcsharp.ruleset
@@ -28,6 +28,7 @@
     <Rule Id="S1125" Action="Info" />
     <Rule Id="S1128" Action="None" />
     <Rule Id="S113" Action="None" />
+    <Rule Id="S1133" Action="Info" />
     <Rule Id="S1134" Action="Warning" />
     <Rule Id="S1135" Action="Info" />
     <Rule Id="S1144" Action="Warning" />
@@ -87,17 +88,20 @@
     <Rule Id="S1944" Action="Warning" />
     <Rule Id="S1994" Action="None" />
     <Rule Id="S2053" Action="Warning" />
+    <Rule Id="S2094" Action="Info" />
     <Rule Id="S2114" Action="Warning" />
     <Rule Id="S2115" Action="Warning" />
     <Rule Id="S2123" Action="Warning" />
     <Rule Id="S2148" Action="None" />
     <Rule Id="S2156" Action="None" />
+    <Rule Id="S2166" Action="Warning" />
     <Rule Id="S2178" Action="Warning" />
     <Rule Id="S2183" Action="Info" />
     <Rule Id="S2184" Action="Info" />
     <Rule Id="S2187" Action="Warning" />
     <Rule Id="S2190" Action="Warning" />
     <Rule Id="S2197" Action="None" />
+    <Rule Id="S2198" Action="Warning" />
     <Rule Id="S2201" Action="Warning" />
     <Rule Id="S2219" Action="Info" />
     <Rule Id="S2221" Action="None" />
@@ -136,6 +140,7 @@
     <Rule Id="S2387" Action="None" />
     <Rule Id="S2436" Action="Warning" />
     <Rule Id="S2437" Action="Warning" />
+    <Rule Id="S2445" Action="Warning" />
     <Rule Id="S2479" Action="Warning" />
     <Rule Id="S2486" Action="Info" />
     <Rule Id="S2551" Action="Warning" />
@@ -162,6 +167,7 @@
     <Rule Id="S2952" Action="None" />
     <Rule Id="S2953" Action="Warning" />
     <Rule Id="S2955" Action="None" />
+    <Rule Id="S2970" Action="Warning" />
     <Rule Id="S2971" Action="Warning" />
     <Rule Id="S2995" Action="Warning" />
     <Rule Id="S2996" Action="Warning" />
@@ -172,6 +178,7 @@
     <Rule Id="S3052" Action="None" />
     <Rule Id="S3059" Action="None" />
     <Rule Id="S3060" Action="Warning" />
+    <Rule Id="S3063" Action="Warning" />
     <Rule Id="S3168" Action="Warning" />
     <Rule Id="S3169" Action="Warning" />
     <Rule Id="S3172" Action="Warning" />
@@ -211,6 +218,7 @@
     <Rule Id="S3366" Action="None" />
     <Rule Id="S3376" Action="Info" />
     <Rule Id="S3397" Action="Info" />
+    <Rule Id="S3398" Action="Info" />
     <Rule Id="S3400" Action="Info" />
     <Rule Id="S3415" Action="Warning" />
     <Rule Id="S3427" Action="Warning" />
@@ -251,6 +259,7 @@
     <Rule Id="S3875" Action="Warning" />
     <Rule Id="S3876" Action="None" />
     <Rule Id="S3877" Action="Warning" />
+    <Rule Id="S3878" Action="Info" />
     <Rule Id="S3880" Action="None" />
     <Rule Id="S3881" Action="Warning" />
     <Rule Id="S3884" Action="Warning" />
@@ -332,7 +341,7 @@
     <Rule Id="S4210" Action="Warning" />
     <Rule Id="S4211" Action="Warning" />
     <Rule Id="S4212" Action="None" />
-    <Rule Id="S4214" Action="Warning" />
+    <Rule Id="S4214" Action="None" />
     <Rule Id="S4220" Action="Warning" />
     <Rule Id="S4225" Action="None" />
     <Rule Id="S4226" Action="None" />
@@ -345,15 +354,17 @@
     <Rule Id="S4428" Action="Warning" />
     <Rule Id="S4433" Action="Warning" />
     <Rule Id="S4456" Action="Warning" />
-    <Rule Id="S4457" Action="Warning" />
+    <Rule Id="S4457" Action="None" />
     <Rule Id="S4462" Action="None" />
     <Rule Id="S4487" Action="Warning" />
     <Rule Id="S4524" Action="Warning" />
+    <Rule Id="S4545" Action="Warning" />
     <Rule Id="S4564" Action="None" />
     <Rule Id="S4581" Action="Warning" />
     <Rule Id="S4583" Action="Warning" />
     <Rule Id="S4586" Action="Warning" />
     <Rule Id="S4635" Action="Warning" />
+    <Rule Id="S4663" Action="Info" />
     <Rule Id="S4830" Action="Warning" />
     <Rule Id="S5034" Action="Warning" />
     <Rule Id="S5445" Action="Warning" />
@@ -368,6 +379,8 @@
     <Rule Id="S6422" Action="Warning" />
     <Rule Id="S6423" Action="None" />
     <Rule Id="S6424" Action="Warning" />
+    <Rule Id="S6507" Action="None" />
+    <Rule Id="S6513" Action="None" />
     <Rule Id="S818" Action="Info" />
     <Rule Id="S881" Action="None" />
     <Rule Id="S907" Action="Warning" />

--- a/src/CrossCutting.Common.Testing/CrossCutting.Common.Testing.csproj
+++ b/src/CrossCutting.Common.Testing/CrossCutting.Common.Testing.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
 </Project>

--- a/src/CrossCutting.Common.Testing/CrossCutting.Common.Testing.csproj
+++ b/src/CrossCutting.Common.Testing/CrossCutting.Common.Testing.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
   </ItemGroup>
 

--- a/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
+++ b/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
+++ b/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
+++ b/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
+++ b/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
+++ b/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
+++ b/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/CrossCutting.Data.Sql/CrossCutting.Data.Sql.csproj
+++ b/src/CrossCutting.Data.Sql/CrossCutting.Data.Sql.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
+++ b/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Utilities.ObjectDumper.Tests/ObjectDumperTests.cs
+++ b/src/CrossCutting.Utilities.ObjectDumper.Tests/ObjectDumperTests.cs
@@ -3,6 +3,19 @@
 public class ObjectDumperTests
 {
     [Fact]
+    public void CanDumpSingle()
+    {
+        // Arrange
+        var input = 2.1f;
+
+        // Act
+        var actual = input.Dump();
+
+        // Assert
+        actual.Should().Be("2.1 [System.Single]");
+    }
+
+    [Fact]
     public void CanDumpSimpleObject()
     {
         // Arrange

--- a/src/CrossCutting.Utilities.ObjectDumper.Tests/ObjectDumperTests.cs
+++ b/src/CrossCutting.Utilities.ObjectDumper.Tests/ObjectDumperTests.cs
@@ -10,7 +10,8 @@ public class ObjectDumperTests
         {
             Name = "John Doe",
             Age = 21,
-            Weight = 80.1
+            Weight = 80.1,
+            Id = Guid.Empty,
         };
 
         // Act
@@ -21,7 +22,8 @@ public class ObjectDumperTests
 @"{
     ""Name"": ""John Doe"" [System.String],
     ""Age"": 21 [System.Int32],
-    ""Weight"": 80.1 [System.Double]
+    ""Weight"": 80.1 [System.Double],
+    ""Id"": ""00000000-0000-0000-0000-000000000000"" [System.Guid]
 } [AnonymousType]");
     }
 

--- a/src/CrossCutting.Utilities.ObjectDumper/DefaultObjectDumperResultBuilder.cs
+++ b/src/CrossCutting.Utilities.ObjectDumper/DefaultObjectDumperResultBuilder.cs
@@ -48,6 +48,10 @@ public class DefaultObjectDumperResultBuilder : IObjectDumperResultBuilder
         {
             _builder.Append(value.ToString().JsonQuote());
         }
+        else if (value is double d)
+        {
+            _builder.Append(d.ToString(CultureInfo.InvariantCulture));
+        }
         else
         {
             _builder.Append(value);

--- a/src/CrossCutting.Utilities.ObjectDumper/DefaultObjectDumperResultBuilder.cs
+++ b/src/CrossCutting.Utilities.ObjectDumper/DefaultObjectDumperResultBuilder.cs
@@ -48,9 +48,9 @@ public class DefaultObjectDumperResultBuilder : IObjectDumperResultBuilder
         {
             _builder.Append(value.ToString().JsonQuote());
         }
-        else if (value is double d)
+        else if (value is IFormattable f)
         {
-            _builder.Append(d.ToString(CultureInfo.InvariantCulture));
+            _builder.Append(f.ToString(null, CultureInfo.InvariantCulture));
         }
         else
         {

--- a/src/CrossCutting.Utilities.ObjectDumper/GlobalUsings.cs
+++ b/src/CrossCutting.Utilities.ObjectDumper/GlobalUsings.cs
@@ -2,6 +2,7 @@
 global using System.Collections;
 global using System.Collections.Generic;
 global using System.ComponentModel;
+global using System.Globalization;
 global using System.Linq;
 global using System.Reflection;
 global using System.Text;

--- a/src/CrossCutting.Utilities.ObjectDumper/Parts/Types/GuidDumper.cs
+++ b/src/CrossCutting.Utilities.ObjectDumper/Parts/Types/GuidDumper.cs
@@ -1,0 +1,26 @@
+﻿namespace CrossCutting.Utilities.ObjectDumper.Parts.Types;
+
+public class GuidDumper : IObjectDumperPart
+{
+    public int Order => 20;
+
+    public bool Process(object? instance, Type instanceType, IObjectDumperResultBuilder builder, int indent, int currentDepth)
+    {
+        if (instance is Guid guid)
+        {
+            builder.AddSingleValue(guid.ToString(null, CultureInfo.InvariantCulture), typeof(Guid));
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public IEnumerable<PropertyDescriptor> ProcessProperties(IEnumerable<PropertyDescriptor> source) => source;
+
+    public bool ShouldProcess(object? instance, IObjectDumperResultBuilder builder, int indent, int currentDepth) => true;
+
+    public bool ShouldProcessProperty(object? instance, PropertyDescriptor propertyDescriptor) => true;
+
+    public object? Transform(object? instance, IObjectDumperResultBuilder builder, int indent, int currentDepth) => instance;
+}

--- a/src/CrossCutting.Utilities.ObjectDumper/Parts/Types/StringDumper.cs
+++ b/src/CrossCutting.Utilities.ObjectDumper/Parts/Types/StringDumper.cs
@@ -6,9 +6,9 @@ public class StringDumper : IObjectDumperPart
 
     public bool Process(object? instance, Type instanceType, IObjectDumperResultBuilder builder, int indent, int currentDepth)
     {
-        if (instance is string)
+        if (instance is string s)
         {
-            builder.AddSingleValue(instance.ToString(), instance.GetType());
+            builder.AddSingleValue(s, typeof(string));
 
             return true;
         }

--- a/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
+++ b/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
+++ b/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Some small things:
- Package updates for all dependencies
- Fixed ObjectDumper for types that implement IFormattable. We want to use invariant culture, so the output always becomes 0.2 instead of 0,2 on Dutch machines