### PR TITLE
Default values for function arguments

### DIFF
--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParseResultTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParseResultTests.cs
@@ -196,6 +196,20 @@ public sealed class FunctionParseResultTests : IDisposable
     }
 
     [Fact]
+    public void GetArgumentInt32Value_Returns_Success_With_DefaultValue_When_ArgumentValue_Is_Not_Found_And_DefaultValue_Is_Supplied()
+    {
+        // Arrange
+        var argument = new FunctionParseResult("Test", Enumerable.Empty<FunctionParseResultArgument>(), CultureInfo.InvariantCulture, default);
+
+        // Act
+        var result = argument.GetArgumentInt32Value(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), 13);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(13);
+    }
+
+    [Fact]
     public void GetArgumentInt64Value_Returns_Invalid_When_ArgumentValue_Is_Invalid()
     {
         // Arrange
@@ -273,6 +287,20 @@ public sealed class FunctionParseResultTests : IDisposable
 
         // Act
         var result = argument.GetArgumentInt64Value(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(13L);
+    }
+
+    [Fact]
+    public void GetArgumentInt64Value_Returns_Success_With_DefaultValue_When_ArgumentValue_Is_Not_Found_And_DefaultValue_Is_Supplied()
+    {
+        // Arrange
+        var argument = new FunctionParseResult("Test", Enumerable.Empty<FunctionParseResultArgument>(), CultureInfo.InvariantCulture, default);
+
+        // Act
+        var result = argument.GetArgumentInt64Value(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), 13L);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -364,6 +392,20 @@ public sealed class FunctionParseResultTests : IDisposable
     }
 
     [Fact]
+    public void GetArgumentDecimalValue_Returns_Success_With_DefaultValue_When_ArgumentValue_Is_Not_Found_And_DefaultValue_Is_Supplied()
+    {
+        // Arrange
+        var argument = new FunctionParseResult("Test", Enumerable.Empty<FunctionParseResultArgument>(), CultureInfo.InvariantCulture, default);
+
+        // Act
+        var result = argument.GetArgumentDecimalValue(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), 13.5M);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(13.5M);
+    }
+
+    [Fact]
     public void GetArgumentBooleanValue_Returns_Invalid_When_ArgumentValue_Is_Invalid()
     {
         // Arrange
@@ -448,6 +490,20 @@ public sealed class FunctionParseResultTests : IDisposable
     }
 
     [Fact]
+    public void GetArgumentBooleanValue_Returns_Success_With_DefaultValue_When_ArgumentValue_Is_Not_Found_And_DefaultValue_Is_Supplied()
+    {
+        // Arrange
+        var argument = new FunctionParseResult("Test", Enumerable.Empty<FunctionParseResultArgument>(), CultureInfo.InvariantCulture, default);
+
+        // Act
+        var result = argument.GetArgumentBooleanValue(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), true);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
     public void GetArgumentDateTimeValue_Returns_Invalid_When_ArgumentValue_Is_Invalid()
     {
         // Arrange
@@ -529,6 +585,21 @@ public sealed class FunctionParseResultTests : IDisposable
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().Be(DateTime.Today);
+    }
+
+    [Fact]
+    public void GetArgumentDateTimeValue_Returns_Success_With_DefaultValue_When_ArgumentValue_Is_Not_Found_And_DefaultValue_Is_Supplied()
+    {
+        // Arrange
+        var argument = new FunctionParseResult("Test", Enumerable.Empty<FunctionParseResultArgument>(), CultureInfo.InvariantCulture, default);
+        var dt = DateTime.Now;
+
+        // Act
+        var result = argument.GetArgumentDateTimeValue(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), dt);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(dt);
     }
 
     public void Dispose() => _provider.Dispose();

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParseResultTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParseResultTests.cs
@@ -56,6 +56,20 @@ public sealed class FunctionParseResultTests : IDisposable
     }
 
     [Fact]
+    public void GetArgumentValue_Returns_Success_When_Argument_Is_Present_And_Literal_And_Ignores_DefaultValue()
+    {
+        // Arrange
+        var argument = new FunctionParseResult("Test", new[] { new LiteralArgument("some value") }, CultureInfo.InvariantCulture, default);
+
+        // Act
+        var result = argument.GetArgumentValue(0, "SomeName", null, _evaluatorMock.Object, "ignored");
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be("some value");
+    }
+
+    [Fact]
     public void GetArgumentValue_Returns_Success_When_Argument_Is_Present_And_Function()
     {
         // Arrange
@@ -67,6 +81,20 @@ public sealed class FunctionParseResultTests : IDisposable
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().Be("Evaluated result");
+    }
+
+    [Fact]
+    public void GetArgumentValue_Returns_Success_With_DefaultValue_When_Argument_Is_Not_Present_But_DefaultValue_Is_Supplied()
+    {
+        // Arrange
+        var argument = new FunctionParseResult("Test", Enumerable.Empty<FunctionParseResultArgument>(), CultureInfo.InvariantCulture, default);
+
+        // Act
+        var result = argument.GetArgumentValue(0, "SomeName", null, _evaluatorMock.Object, "some value");
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be("some value");
     }
 
     [Fact]
@@ -109,6 +137,20 @@ public sealed class FunctionParseResultTests : IDisposable
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().Be("some value");
+    }
+
+    [Fact]
+    public void GetArgumentStringValue_Returns_Success_With_DefaultValue_When_ArgumentValue_Is_Not_Found_And_DefaultValue_Is_Supplied()
+    {
+        // Arrange
+        var argument = new FunctionParseResult("Test", Enumerable.Empty<FunctionParseResultArgument>(), CultureInfo.InvariantCulture, default);
+
+        // Act
+        var result = argument.GetArgumentStringValue(0, "SomeName", null, _evaluatorMock.Object, "default value");
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be("default value");
     }
 
     [Fact]

--- a/src/CrossCutting.Utilities.Parsers/FunctionParseResult.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParseResult.cs
@@ -20,22 +20,48 @@ public record FunctionParseResult
             ? Result<object?>.Invalid($"Missing argument: {argumentName}")
             : Arguments[index].GetValue(context, evaluator);
 
-    public Result<string> GetArgumentStringValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator)
-    {
-        var argumentValueResult = GetArgumentValue(index, argumentName, context, evaluator);
-        if (!argumentValueResult.IsSuccessful())
-        {
-            return Result<string>.FromExistingResult(argumentValueResult);
-        }
+    public Result<object?> GetArgumentValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, object? defaultValue)
+        => index + 1 > Arguments.Count
+            ? Result<object?>.Success(defaultValue)
+            : Arguments[index].GetValue(context, evaluator);
 
-        return argumentValueResult.Value is string stringValue
-            ? Result<string>.Success(stringValue)
-            : Result<string>.Invalid($"{argumentName} is not of type string");
-    }
+    public Result<string> GetArgumentStringValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator) => ProcessStringArgumentResult(argumentName, GetArgumentValue(index, argumentName, context, evaluator));
+
+    public Result<string> GetArgumentStringValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, string defaultValue)
+        => ProcessStringArgumentResult(argumentName, GetArgumentValue(index, argumentName, context, evaluator, defaultValue));
 
     public Result<int> GetArgumentInt32Value(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+        => ProcessInt32ArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator));
+
+    public Result<int> GetArgumentInt32Value(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser, int defaultValue)
+        => ProcessInt32ArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator, defaultValue));
+
+    public Result<long> GetArgumentInt64Value(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+        => ProcessInt64ArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator));
+
+    public Result<long> GetArgumentInt64Value(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser, long defaultValue)
+        => ProcessInt64ArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator, defaultValue));
+
+    public Result<decimal> GetArgumentDecimalValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+        => ProcessDecimalArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator));
+
+    public Result<decimal> GetArgumentDecimalValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser, decimal defaultValue)
+        => ProcessDecimalArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator, defaultValue));
+
+    public Result<bool> GetArgumentBooleanValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+        => ProcessBooleanArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator));
+
+    public Result<bool> GetArgumentBooleanValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser, bool defaultValue)
+        => ProcessBooleanArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator, defaultValue));
+
+    public Result<DateTime> GetArgumentDateTimeValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+        => ProcessDateTimeArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator));
+
+    public Result<DateTime> GetArgumentDateTimeValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser, DateTime defaultValue)
+        => ProcessDateTimeArgumentResult(argumentName, parser, GetArgumentValue(index, argumentName, context, evaluator, defaultValue));
+
+    private Result<int> ProcessInt32ArgumentResult(string argumentName, IExpressionParser parser, Result<object?> argumentValueResult)
     {
-        var argumentValueResult = GetArgumentValue(index, argumentName, context, evaluator);
         if (!argumentValueResult.IsSuccessful())
         {
             return Result<int>.FromExistingResult(argumentValueResult);
@@ -62,9 +88,8 @@ public record FunctionParseResult
             : Result<int>.Invalid($"{argumentName} is not of type integer");
     }
 
-    public Result<long> GetArgumentInt64Value(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+    private Result<long> ProcessInt64ArgumentResult(string argumentName, IExpressionParser parser, Result<object?> argumentValueResult)
     {
-        var argumentValueResult = GetArgumentValue(index, argumentName, context, evaluator);
         if (!argumentValueResult.IsSuccessful())
         {
             return Result<long>.FromExistingResult(argumentValueResult);
@@ -79,7 +104,7 @@ public record FunctionParseResult
         {
             return Result<long>.Invalid($"{argumentName} is not of type long integer");
         }
-        
+
         var parseResult = parser.Parse(s, FormatProvider, Context);
         if (!parseResult.IsSuccessful())
         {
@@ -91,9 +116,8 @@ public record FunctionParseResult
             : Result<long>.Invalid($"{argumentName} is not of type long integer");
     }
 
-    public Result<decimal> GetArgumentDecimalValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+    private Result<decimal> ProcessDecimalArgumentResult(string argumentName, IExpressionParser parser, Result<object?> argumentValueResult)
     {
-        var argumentValueResult = GetArgumentValue(index, argumentName, context, evaluator);
         if (!argumentValueResult.IsSuccessful())
         {
             return Result<decimal>.FromExistingResult(argumentValueResult);
@@ -120,9 +144,8 @@ public record FunctionParseResult
             : Result<decimal>.Invalid($"{argumentName} is not of type decimal");
     }
 
-    public Result<bool> GetArgumentBooleanValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+    private Result<bool> ProcessBooleanArgumentResult(string argumentName, IExpressionParser parser, Result<object?> argumentValueResult)
     {
-        var argumentValueResult = GetArgumentValue(index, argumentName, context, evaluator);
         if (!argumentValueResult.IsSuccessful())
         {
             return Result<bool>.FromExistingResult(argumentValueResult);
@@ -137,21 +160,20 @@ public record FunctionParseResult
         {
             return Result<bool>.Invalid($"{argumentName} is not of type boolean");
         }
-        
+
         var parseResult = parser.Parse(s, FormatProvider, Context);
         if (!parseResult.IsSuccessful())
         {
             return Result<bool>.Invalid($"{argumentName} is not of type boolean");
         }
-        
+
         return parseResult.Value is bool b2
             ? Result<bool>.Success(b2)
             : Result<bool>.Invalid($"{argumentName} is not of type boolean");
     }
 
-    public Result<DateTime> GetArgumentDateTimeValue(int index, string argumentName, object? context, IFunctionParseResultEvaluator evaluator, IExpressionParser parser)
+    private Result<DateTime> ProcessDateTimeArgumentResult(string argumentName, IExpressionParser parser, Result<object?> argumentValueResult)
     {
-        var argumentValueResult = GetArgumentValue(index, argumentName, context, evaluator);
         if (!argumentValueResult.IsSuccessful())
         {
             return Result<DateTime>.FromExistingResult(argumentValueResult);
@@ -175,5 +197,17 @@ public record FunctionParseResult
         return parseResult.Value is DateTime dt2
             ? Result<DateTime>.Success(dt2)
             : Result<DateTime>.Invalid($"{argumentName} is not of type datetime");
+    }
+
+    private static Result<string> ProcessStringArgumentResult(string argumentName, Result<object?> argumentValueResult)
+    {
+        if (!argumentValueResult.IsSuccessful())
+        {
+            return Result<string>.FromExistingResult(argumentValueResult);
+        }
+
+        return argumentValueResult.Value is string stringValue
+            ? Result<string>.Success(stringValue)
+            : Result<string>.Invalid($"{argumentName} is not of type string");
     }
 }


### PR DESCRIPTION
Added support for supplying default values in function arguments in FunctionParser, so you can make arguments optional.