### PR TITLE
Scoped component registration

### DIFF
--- a/src/CrossCutting.Data.Sql.Tests/IntegrationTests.cs
+++ b/src/CrossCutting.Data.Sql.Tests/IntegrationTests.cs
@@ -5,6 +5,7 @@ public sealed class IntegrationTests : IDisposable
     private readonly ITestRepository _repository;
     private readonly DbConnection _connection;
     private readonly ServiceProvider _serviceProvider;
+    private readonly IServiceScope _scope;
 
     public IntegrationTests()
     {
@@ -21,8 +22,9 @@ public sealed class IntegrationTests : IDisposable
             .AddScoped<IDatabaseCommandProcessor<TestEntity>, DatabaseCommandProcessor<TestEntity, TestEntityBuilder>>()
             .AddScoped<IDatabaseEntityRetriever<TestEntity>, DatabaseEntityRetriever<TestEntity>>()
             .AddScoped<ITestRepository, TestRepository>()
-            .BuildServiceProvider();
-        _repository = _serviceProvider.GetRequiredService<ITestRepository>();
+            .BuildServiceProvider(true);
+        _scope = _serviceProvider.CreateScope();
+        _repository = _scope.ServiceProvider.GetRequiredService<ITestRepository>();
     }
 
     [Fact]
@@ -126,6 +128,7 @@ public sealed class IntegrationTests : IDisposable
 
     public void Dispose()
     {
+        _scope.Dispose();
         _serviceProvider.Dispose();
         _connection.Dispose();
     }

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionParserTests.cs
@@ -3,8 +3,13 @@
 public sealed class ExpressionParserTests : IDisposable
 {
     private readonly ServiceProvider _provider;
+    private readonly IServiceScope _scope;
 
-    public ExpressionParserTests() => _provider = new ServiceCollection().AddParsers().BuildServiceProvider();
+    public ExpressionParserTests()
+    {
+        _provider = new ServiceCollection().AddParsers().BuildServiceProvider(true);
+        _scope = _provider.CreateScope();
+    }
 
     [Fact]
     public void Parse_Parses_true_Correctly()
@@ -157,10 +162,14 @@ public sealed class ExpressionParserTests : IDisposable
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().BeEquivalentTo(new DateTime(2019, 1, 2));
+        result.Value.Should().BeEquivalentTo(new DateTime(2019, 1, 2, 0, 0, 0, DateTimeKind.Unspecified));
     }
 
-    public void Dispose() => _provider.Dispose();
+    public void Dispose()
+    {
+        _scope.Dispose();
+        _provider.Dispose();
+    }
 
-    private IExpressionParser CreateSut() => _provider.GetRequiredService<IExpressionParser>();
+    private IExpressionParser CreateSut() => _scope.ServiceProvider.GetRequiredService<IExpressionParser>();
 }

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -3,7 +3,7 @@
 public sealed class FormattableStringParserTests : IDisposable
 {
     private ServiceProvider? _provider;
-
+    private IServiceScope? _scope;
     private const string ReplacedValue = "replaced name";
 
     [Fact]
@@ -100,15 +100,20 @@ public sealed class FormattableStringParserTests : IDisposable
         result.Status.Should().Be(ResultStatus.Ok);
     }
 
-    public void Dispose() => _provider?.Dispose();
+    public void Dispose()
+    {
+        _scope?.Dispose();
+        _provider?.Dispose();
+    }
 
     private IFormattableStringParser CreateSut()
     {
         _provider = new ServiceCollection()
         .AddParsers()
             .AddSingleton<IPlaceholderProcessor, MyPlaceholderProcessor>()
-            .BuildServiceProvider();
-        return _provider.GetRequiredService<IFormattableStringParser>();
+            .BuildServiceProvider(true);
+        _scope = _provider.CreateScope();
+        return _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>();
     }
 
     private sealed class MyPlaceholderProcessor : IPlaceholderProcessor

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParseResultTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParseResultTests.cs
@@ -4,6 +4,7 @@ public sealed class FunctionParseResultTests : IDisposable
 {
     private readonly Mock<IFunctionParseResultEvaluator> _evaluatorMock = new();
     private readonly ServiceProvider _provider;
+    private readonly IServiceScope _scope;
 
     public FunctionParseResultTests()
     {
@@ -24,7 +25,8 @@ public sealed class FunctionParseResultTests : IDisposable
                             "UnknownExpressionString" => Result<object?>.Success("%#$&"),
                             _ => Result<object?>.NotSupported("Only Parsed result function is supported")
                         });
-        _provider = new ServiceCollection().AddParsers().BuildServiceProvider();
+        _provider = new ServiceCollection().AddParsers().BuildServiceProvider(true);
+        _scope = _provider.CreateScope();
     }
 
     [Fact]
@@ -34,7 +36,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentValueResult(1, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentValueResult(1, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -48,7 +50,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -62,7 +64,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), "ignored");
+        var result = argument.GetArgumentValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>(), "ignored");
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -76,7 +78,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("MyNestedFunction");
 
         // Act
-        var result = argument.GetArgumentValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -90,7 +92,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithoutArguments();
 
         // Act
-        var result = argument.GetArgumentValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), "some value");
+        var result = argument.GetArgumentValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>(), "some value");
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -104,7 +106,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentStringValueResult(1, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentStringValueResult(1, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -118,7 +120,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("NumericFunction");
 
         // Act
-        var result = argument.GetArgumentStringValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentStringValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -132,7 +134,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentStringValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentStringValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -146,7 +148,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithoutArguments();
 
         // Act
-        var result = argument.GetArgumentStringValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), "default value");
+        var result = argument.GetArgumentStringValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>(), "default value");
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -160,7 +162,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentInt32ValueResult(1, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt32ValueResult(1, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -174,7 +176,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("NumericFunction");
 
         // Act
-        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -188,7 +190,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunction");
 
         // Act
-        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -202,7 +204,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("UnknownExpressionString");
 
         // Act
-        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -216,7 +218,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -230,7 +232,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("NumericFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -244,7 +246,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithoutArguments();
 
         // Act
-        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), 13);
+        var result = argument.GetArgumentInt32ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>(), 13);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -258,7 +260,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentInt64ValueResult(1, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt64ValueResult(1, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -272,7 +274,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("LongFunction");
 
         // Act
-        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -286,7 +288,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunction");
 
         // Act
-        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -300,7 +302,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("UnknownExpressionString");
 
         // Act
-        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -314,7 +316,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -328,7 +330,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("LongFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -342,7 +344,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithoutArguments();
 
         // Act
-        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), 13L);
+        var result = argument.GetArgumentInt64ValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>(), 13L);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -356,7 +358,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentDecimalValueResult(1, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDecimalValueResult(1, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -370,7 +372,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DecimalFunction");
 
         // Act
-        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -384,7 +386,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunction");
 
         // Act
-        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -398,7 +400,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("UnknownExpressionString");
 
         // Act
-        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -412,7 +414,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -426,7 +428,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DecimalFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -440,7 +442,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithoutArguments();
 
         // Act
-        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), 13.5M);
+        var result = argument.GetArgumentDecimalValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>(), 13.5M);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -454,7 +456,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentBooleanValueResult(1, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentBooleanValueResult(1, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -468,7 +470,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("BooleanFunction");
 
         // Act
-        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -482,7 +484,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunction");
 
         // Act
-        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -496,7 +498,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("UnknownExpressionString");
 
         // Act
-        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -510,7 +512,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -524,7 +526,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("BooleanFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -538,7 +540,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithoutArguments();
 
         // Act
-        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), true);
+        var result = argument.GetArgumentBooleanValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>(), true);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -552,7 +554,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithLiteralArgument();
 
         // Act
-        var result = argument.GetArgumentDateTimeValueResult(1, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDateTimeValueResult(1, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -566,7 +568,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunction");
 
         // Act
-        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -580,7 +582,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("NumericFunction");
 
         // Act
-        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -594,7 +596,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("UnknownExpressionString");
 
         // Act
-        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -608,7 +610,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("NumericFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -622,7 +624,7 @@ public sealed class FunctionParseResultTests : IDisposable
         var argument = CreateFunctionParseResultWithFunctionArgument("DateTimeFunctionAsString");
 
         // Act
-        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>());
+        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -637,14 +639,18 @@ public sealed class FunctionParseResultTests : IDisposable
         var dt = DateTime.Now;
 
         // Act
-        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _provider.GetRequiredService<IExpressionParser>(), dt);
+        var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", null, _evaluatorMock.Object, _scope.ServiceProvider.GetRequiredService<IExpressionParser>(), dt);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().Be(dt);
     }
 
-    public void Dispose() => _provider.Dispose();
+    public void Dispose()
+    {
+        _scope.Dispose();
+        _provider.Dispose();
+    }
     
     private static FunctionParseResult CreateFunctionParseResultWithoutArguments()
         => new FunctionParseResultBuilder()

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
@@ -270,8 +270,9 @@ public sealed class FunctionParserTests : IDisposable
     public void Parse_Returns_Error_When_ArgumentProcessor_Returns_Error()
     {
         // Arrange
-        using var provider = new ServiceCollection().AddParsers().AddSingleton<IFunctionParserArgumentProcessor, ErrorArgumentProcessor>().BuildServiceProvider();
-        var sut = provider.GetRequiredService<IFunctionParser>();
+        using var provider = new ServiceCollection().AddParsers().AddSingleton<IFunctionParserArgumentProcessor, ErrorArgumentProcessor>().BuildServiceProvider(true);
+        using var scope = provider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<IFunctionParser>();
         var input = "MYFUNCTION(some argument)";
 
         // Act
@@ -286,8 +287,9 @@ public sealed class FunctionParserTests : IDisposable
     public void Parse_Returns_Error_When_NameProcessor_Returns_Error()
     {
         // Arrange
-        using var provider = new ServiceCollection().AddParsers().AddSingleton<IFunctionParserNameProcessor, ErrorNameProcessor>().BuildServiceProvider();
-        var sut = provider.GetRequiredService<IFunctionParser>();
+        using var provider = new ServiceCollection().AddParsers().AddSingleton<IFunctionParserNameProcessor, ErrorNameProcessor>().BuildServiceProvider(true);
+        using var scope = provider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<IFunctionParser>();
         var input = "MYFUNCTION(some argument)";
 
         // Act

--- a/src/CrossCutting.Utilities.Parsers.Tests/MathematicExpressionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/MathematicExpressionParserTests.cs
@@ -3,6 +3,7 @@
 public sealed class MathematicExpressionParserTests : IDisposable
 {
     private ServiceProvider? _provider;
+    private IServiceScope? _scope;
 
     [Fact]
     public void Can_Add_One_And_One()
@@ -430,8 +431,9 @@ public sealed class MathematicExpressionParserTests : IDisposable
         _provider = new ServiceCollection()
             .AddParsers()
             .AddSingleton<IExpressionParser>(new MyMathematicExpressionParser(dlg))
-            .BuildServiceProvider();
-        return _provider.GetRequiredService<IMathematicExpressionParser>();
+            .BuildServiceProvider(true);
+        _scope = _provider.CreateScope();
+        return _scope.ServiceProvider.GetRequiredService<IMathematicExpressionParser>();
     }
 
     private Result<object?> ParseExpressionDelegateInt32(string arg, IFormatProvider formatProvider)
@@ -469,7 +471,11 @@ public sealed class MathematicExpressionParserTests : IDisposable
             ? Result<object?>.Success(result)
             : Result<object?>.Invalid($"Could not parse {arg} to short");
 
-    public void Dispose() => _provider?.Dispose();
+    public void Dispose()
+    {
+        _scope?.Dispose();
+        _provider?.Dispose();
+    }
 
     private sealed class MyMathematicExpressionParser : IExpressionParser
     {

--- a/src/CrossCutting.Utilities.Parsers.Tests/StringFormatParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/StringFormatParserTests.cs
@@ -60,7 +60,7 @@ public class StringFormatParserTests
     {
         // Arrange
         const string FormatString = "Hello {0}{1} on {2:dd-MM-yyyy}";
-        var args = new object[] { "world", "!", new DateTime(2018, 1, 1) }.ToArray();
+        var args = new object[] { "world", "!", new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Unspecified) }.ToArray();
 
         // Act
         var actual = StringFormatParser.Parse(FormatString, args);
@@ -69,7 +69,7 @@ public class StringFormatParserTests
         actual.IsSuccessful.Should().BeTrue();
         actual.ErrorMessages.Should().BeEmpty();
         var contents = string.Join("|", actual.Values.Select(kvp => string.Format("{0};{1}", kvp.Key, kvp.Value)));
-        contents.Should().Be($"0;world|1;!|2;{new DateTime(2018, 1, 1)}");
+        contents.Should().Be($"0;world|1;!|2;{new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Unspecified)}");
     }
 
     [Fact]

--- a/src/CrossCutting.Utilities.Parsers/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/ServiceCollectionExtensions.cs
@@ -12,57 +12,57 @@ public static class ServiceCollectionExtensions
 
     private static IServiceCollection AddExpressionParser(this IServiceCollection services)
         => services
-        .AddSingleton<IExpressionParser, ExpressionParser>()
-        .AddSingleton<IExpressionParserProcessor, BooleanExpressionParserProcessor>()
-        .AddSingleton<IExpressionParserProcessor, ContextExpressionParserProcessor>()
-        .AddSingleton<IExpressionParserProcessor, NullExpressionParserProcessor>()
-        .AddSingleton<IExpressionParserProcessor, StringExpressionParserProcessor>()
-        .AddSingleton<IExpressionParserProcessor, NumericExpressionParserProcessor>()
-        .AddSingleton<IExpressionParserProcessor, DateTimeExpressionParserProcessor>();
+        .AddScoped<IExpressionParser, ExpressionParser>()
+        .AddScoped<IExpressionParserProcessor, BooleanExpressionParserProcessor>()
+        .AddScoped<IExpressionParserProcessor, ContextExpressionParserProcessor>()
+        .AddScoped<IExpressionParserProcessor, NullExpressionParserProcessor>()
+        .AddScoped<IExpressionParserProcessor, StringExpressionParserProcessor>()
+        .AddScoped<IExpressionParserProcessor, NumericExpressionParserProcessor>()
+        .AddScoped<IExpressionParserProcessor, DateTimeExpressionParserProcessor>();
 
     private static IServiceCollection AddExpressionStringParser(this IServiceCollection services)
         => services
-        .AddSingleton<IExpressionStringParser, ExpressionStringParser>()
-        .AddSingleton<IExpressionStringParserProcessor, EmptyExpressionProcessor>()
-        .AddSingleton<IExpressionStringParserProcessor, PipedExpressionProcessor>()
-        .AddSingleton<IExpressionStringParserProcessor, ConcatenateExpressionProcessor>()
-        .AddSingleton<IExpressionStringParserProcessor, LiteralExpressionProcessor>()
-        .AddSingleton<IExpressionStringParserProcessor, OnlyEqualsExpressionProcessor>()
-        .AddSingleton<IExpressionStringParserProcessor, FormattableStringExpressionProcessor>()
-        .AddSingleton<IExpressionStringParserProcessor, MathematicExpressionProcessor>()
-        .AddSingleton<IExpressionStringParserProcessor, EqualOperator>()
-        .AddSingleton<IExpressionStringParserProcessor, NotEqualOperator>()
-        .AddSingleton<IExpressionStringParserProcessor, GreaterThanOperator>()
-        .AddSingleton<IExpressionStringParserProcessor, GreaterOrEqualThanOperator>()
-        .AddSingleton<IExpressionStringParserProcessor, SmallerThanOperator>()
-        .AddSingleton<IExpressionStringParserProcessor, SmallerOrEqualThanOperator>();
+        .AddScoped<IExpressionStringParser, ExpressionStringParser>()
+        .AddScoped<IExpressionStringParserProcessor, EmptyExpressionProcessor>()
+        .AddScoped<IExpressionStringParserProcessor, PipedExpressionProcessor>()
+        .AddScoped<IExpressionStringParserProcessor, ConcatenateExpressionProcessor>()
+        .AddScoped<IExpressionStringParserProcessor, LiteralExpressionProcessor>()
+        .AddScoped<IExpressionStringParserProcessor, OnlyEqualsExpressionProcessor>()
+        .AddScoped<IExpressionStringParserProcessor, FormattableStringExpressionProcessor>()
+        .AddScoped<IExpressionStringParserProcessor, MathematicExpressionProcessor>()
+        .AddScoped<IExpressionStringParserProcessor, EqualOperator>()
+        .AddScoped<IExpressionStringParserProcessor, NotEqualOperator>()
+        .AddScoped<IExpressionStringParserProcessor, GreaterThanOperator>()
+        .AddScoped<IExpressionStringParserProcessor, GreaterOrEqualThanOperator>()
+        .AddScoped<IExpressionStringParserProcessor, SmallerThanOperator>()
+        .AddScoped<IExpressionStringParserProcessor, SmallerOrEqualThanOperator>();
 
     private static IServiceCollection AddFunctionParser(this IServiceCollection services)
         => services
-        .AddSingleton<IFunctionParser, FunctionParser>()
-        .AddSingleton<IFunctionParserNameProcessor, DefaultFunctionParserNameProcessor>()
-        .AddSingleton<IFunctionParserArgumentProcessor, FormattableStringFunctionParserArgumentProcessor>()
-        .AddSingleton<IFunctionParseResultEvaluator, DefaultFunctionParseResultEvaluator>();
+        .AddScoped<IFunctionParser, FunctionParser>()
+        .AddScoped<IFunctionParserNameProcessor, DefaultFunctionParserNameProcessor>()
+        .AddScoped<IFunctionParserArgumentProcessor, FormattableStringFunctionParserArgumentProcessor>()
+        .AddScoped<IFunctionParseResultEvaluator, DefaultFunctionParseResultEvaluator>();
 
     private static IServiceCollection AddFormattableStringParser(this IServiceCollection services)
         => services
-        .AddSingleton<IFormattableStringParser, FormattableStringParser>()
-        .AddSingleton<IFormattableStringStateProcessor, OpenSignProcessor>()
-        .AddSingleton<IFormattableStringStateProcessor, CloseSignProcessor>()
-        .AddSingleton<IFormattableStringStateProcessor, PlaceholderProcessor>()
-        .AddSingleton<IFormattableStringStateProcessor, ResultProcessor>()
-        .AddSingleton<IPlaceholderProcessor, UnknownPlaceholderProcessor>(); // used by CloseSignProcessor
+        .AddScoped<IFormattableStringParser, FormattableStringParser>()
+        .AddScoped<IFormattableStringStateProcessor, OpenSignProcessor>()
+        .AddScoped<IFormattableStringStateProcessor, CloseSignProcessor>()
+        .AddScoped<IFormattableStringStateProcessor, PlaceholderProcessor>()
+        .AddScoped<IFormattableStringStateProcessor, ResultProcessor>()
+        .AddScoped<IPlaceholderProcessor, UnknownPlaceholderProcessor>(); // used by CloseSignProcessor
 
     private static IServiceCollection AddMathematicExpressionParser(this IServiceCollection services)
         => services
-        .AddSingleton<IMathematicExpressionParser, MathematicExpressionParser>()
-        .AddSingleton<IMathematicExpressionProcessor, Validate>()
-        .AddSingleton<IMathematicExpressionProcessor, Recursion>()
-        .AddSingleton<IMathematicExpressionProcessor, MathematicOperators>()
-        .AddSingleton<IMathematicExpressionValidator, NullOrEmptyValidator>()
-        .AddSingleton<IMathematicExpressionValidator, TemporaryDelimiterValidator>()
-        .AddSingleton<IMathematicExpressionValidator, StartWithOperatorValidator>()
-        .AddSingleton<IMathematicExpressionValidator, EndWithOperatorValidator>()
-        .AddSingleton<IMathematicExpressionValidator, EmptyValuePartValidator>()
-        .AddSingleton<IMathematicExpressionValidator, BraceValidator>();
+        .AddScoped<IMathematicExpressionParser, MathematicExpressionParser>()
+        .AddScoped<IMathematicExpressionProcessor, Validate>()
+        .AddScoped<IMathematicExpressionProcessor, Recursion>()
+        .AddScoped<IMathematicExpressionProcessor, MathematicOperators>()
+        .AddScoped<IMathematicExpressionValidator, NullOrEmptyValidator>()
+        .AddScoped<IMathematicExpressionValidator, TemporaryDelimiterValidator>()
+        .AddScoped<IMathematicExpressionValidator, StartWithOperatorValidator>()
+        .AddScoped<IMathematicExpressionValidator, EndWithOperatorValidator>()
+        .AddScoped<IMathematicExpressionValidator, EmptyValuePartValidator>()
+        .AddScoped<IMathematicExpressionValidator, BraceValidator>();
 }


### PR DESCRIPTION
Like the title says: Changing Singleton to Scoped registration for parser registrations in ServiceCollection.

This might now sound useful, but you need this in case you want placeholder processors that are scoped to the current request, for example return the user name of the current call.