### PR TITLE
Added support for expressions in FormattableStringParser

### DIFF
--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionStringParserTests.cs
@@ -87,7 +87,21 @@ public sealed class ExpressionStringParserTests : IDisposable
     }
 
     [Fact]
-    public void Parse_Returns_Success_Result_From_Formattable_String_When_Found()
+    public void Parse_Returns_Success_Result_From_Formattable_String_When_Found_And_FormattableStringProcessor_Is_Not_Null()
+    {
+        // Arrange
+        var input = "=@\"Hello {Name}!\"";
+
+        // Act
+        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be("Hello replaced name!");
+    }
+
+    [Fact]
+    public void Parse_Returns_Formattable_String_Unprocessed_When_Found_And_FormattableStringProcessor_Is_Null()
     {
         // Arrange
         var input = "=@\"Hello {Name}!\"";
@@ -97,7 +111,7 @@ public sealed class ExpressionStringParserTests : IDisposable
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().Be("Hello replaced name!");
+        result.Value.Should().Be("Hello {Name}!");
     }
 
     [Fact]
@@ -107,7 +121,7 @@ public sealed class ExpressionStringParserTests : IDisposable
         var input = "=@\"Hello {Kaboom}!\"";
 
         // Act
-        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture);
+        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Error);
@@ -191,7 +205,7 @@ public sealed class ExpressionStringParserTests : IDisposable
         var input = "=MYFUNCTION2(@\"Hello {Name}!\")";
 
         // Act
-        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture);
+        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -275,7 +289,7 @@ public sealed class ExpressionStringParserTests : IDisposable
         var input = "=\"Hello \" & @\"{Name}!\"";
 
         // Act
-        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture);
+        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -703,7 +717,7 @@ public sealed class ExpressionStringParserTests : IDisposable
     {
         public int Order => 10;
 
-        public Result<string> Process(string value, IFormatProvider formatProvider, object? context)
+        public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
                 ? Result<string>.Success(ReplacedValue)
                 : Result<string>.Error($"Unsupported placeholder name: {value}");

--- a/src/CrossCutting.Utilities.Parsers.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,16 @@
+﻿namespace CrossCutting.Utilities.Parsers.Tests.Extensions;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddParsers_Registers_All_Types_Without_Errors()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+
+        // Act & Assert
+        serviceCollection
+            .Invoking(x => x.AddParsers().BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }))
+            .Should().NotThrow();
+    }
+}

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -101,7 +101,7 @@ public sealed class FormattableStringParserTests : IDisposable
     }
 
     [Fact]
-    public void Parse_Works_With_ExpressionString()
+    public void Parse_Works_With_ExpressionString_Containing_Function()
     {
         // Arrange
         const string Input = "Hello {MyFunction()}!";
@@ -112,6 +112,20 @@ public sealed class FormattableStringParserTests : IDisposable
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().Be("Hello function result!");
+    }
+
+    [Fact]
+    public void Parse_Works_With_ExpressionString()
+    {
+        // Arrange
+        const string Input = "I can add 1 to 2, this results in {1 + 1}";
+
+        // Act
+        var result = CreateSut().Parse(Input, CultureInfo.InvariantCulture);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be("I can add 1 to 2, this results in 2");
     }
 
     [Fact]

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
@@ -56,7 +56,7 @@ public sealed class FunctionParserTests : IDisposable
         var input = "MYFUNCTION(@\"Hello, {Name}!\",b,c)";
 
         // Act
-        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture);
+        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -351,7 +351,7 @@ public sealed class FunctionParserTests : IDisposable
     {
         public int Order => 1;
 
-        public Result<FunctionParseResultArgument> Process(string stringArgument, IReadOnlyCollection<FunctionParseResult> results, IFormatProvider formatProvider, object? context)
+        public Result<FunctionParseResultArgument> Process(string stringArgument, IReadOnlyCollection<FunctionParseResult> results, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
             => Result<FunctionParseResultArgument>.Error("Kaboom");
     }
 
@@ -366,7 +366,7 @@ public sealed class FunctionParserTests : IDisposable
     {
         public int Order => 10;
 
-        public Result<string> Process(string value, IFormatProvider formatProvider, object? context)
+        public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
                 ? Result<string>.Success(ReplacedValue)
                 : Result<string>.Error($"Unsupported placeholder name: {value}");

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IExpressionStringParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IExpressionStringParser.cs
@@ -2,5 +2,5 @@
 
 public interface IExpressionStringParser
 {
-    Result<object?> Parse(string input, IFormatProvider formatProvider, object? context);
+    Result<object?> Parse(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionParser.cs
@@ -2,5 +2,5 @@
 
 public interface IFunctionParser
 {
-    Result<FunctionParseResult> Parse(string input, IFormatProvider formatProvider, object? context);
+    Result<FunctionParseResult> Parse(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionParserArgumentProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionParserArgumentProcessor.cs
@@ -3,5 +3,5 @@
 public interface IFunctionParserArgumentProcessor
 {
     int Order { get; }
-    Result<FunctionParseResultArgument> Process(string stringArgument, IReadOnlyCollection<FunctionParseResult> results, IFormatProvider formatProvider, object? context);
+    Result<FunctionParseResultArgument> Process(string stringArgument, IReadOnlyCollection<FunctionParseResult> results, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IPlaceholderProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IPlaceholderProcessor.cs
@@ -3,5 +3,5 @@
 public interface IPlaceholderProcessor
 {
     int Order { get; }
-    Result<string> Process(string value, IFormatProvider formatProvider, object? context);
+    Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionParser.cs
@@ -6,13 +6,20 @@ public class ExpressionParser : IExpressionParser
 
     public ExpressionParser(IEnumerable<IExpressionParserProcessor> processors)
     {
+        ArgumentGuard.IsNotNull(processors, nameof(processors));
+
         _processors = processors;
     }
 
     public Result<object?> Parse(string value, IFormatProvider formatProvider, object? context)
-        => _processors
+    {
+        ArgumentGuard.IsNotNull(value, nameof(value));
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+
+        return _processors
             .OrderBy(x => x.Order)
             .Select(x => x.Parse(value, formatProvider, context))
             .FirstOrDefault(x => x.Status != ResultStatus.Continue)
                 ?? Result<object?>.NotSupported($"Unknown expression type found in fragment: {value}");
+    }
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParser.cs
@@ -13,6 +13,11 @@ public class ExpressionStringParser : IExpressionStringParser
         IFunctionParseResultEvaluator evaluator,
         IEnumerable<IExpressionStringParserProcessor> processors)
     {
+        ArgumentGuard.IsNotNull(functionParser, nameof(functionParser));
+        ArgumentGuard.IsNotNull(expressionParser, nameof(expressionParser));
+        ArgumentGuard.IsNotNull(evaluator, nameof(evaluator));
+        ArgumentGuard.IsNotNull(processors, nameof(processors));
+
         _functionParser = functionParser;
         _expressionParser = expressionParser;
         _evaluator = evaluator;
@@ -21,7 +26,11 @@ public class ExpressionStringParser : IExpressionStringParser
 
     public Result<object?> Parse(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
     {
+        ArgumentGuard.IsNotNull(input, nameof(input));
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+
         var state = new ExpressionStringParserState(input, formatProvider, context, this, formattableStringParser);
+
         return _processors
             .OrderBy(x => x.Order)
             .Select(x => x.Process(state))

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParser.cs
@@ -19,9 +19,9 @@ public class ExpressionStringParser : IExpressionStringParser
         _processors = processors;
     }
 
-    public Result<object?> Parse(string input, IFormatProvider formatProvider, object? context)
+    public Result<object?> Parse(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
     {
-        var state = new ExpressionStringParserState(input, formatProvider, context, this);
+        var state = new ExpressionStringParserState(input, formatProvider, context, this, formattableStringParser);
         return _processors
             .OrderBy(x => x.Order)
             .Select(x => x.Process(state))
@@ -32,7 +32,7 @@ public class ExpressionStringParser : IExpressionStringParser
     private Result<object?> EvaluateSimpleExpression(ExpressionStringParserState state)
     {
         // =something else, we can try function
-        var functionResult = _functionParser.Parse(state.Input.Substring(1), state.FormatProvider, state.Context);
+        var functionResult = _functionParser.Parse(state.Input.Substring(1), state.FormatProvider, state.Context, state.FormattableStringParser);
         if (functionResult.Status == ResultStatus.NotFound)
         {
             return Result<object?>.FromExistingResult(functionResult);

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/ConcatenateExpressionProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/ConcatenateExpressionProcessor.cs
@@ -14,7 +14,7 @@ public class ConcatenateExpressionProcessor : IExpressionStringParserProcessor
             var builder = new StringBuilder();
             foreach (var item in split)
             {
-                var result = state.Parser.Parse($"={item}", state.FormatProvider, state.Context);
+                var result = state.Parser.Parse($"={item}", state.FormatProvider, state.Context, state.FormattableStringParser);
                 if (!result.IsSuccessful())
                 {
                     return result;

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/FormattableStringExpressionProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/FormattableStringExpressionProcessor.cs
@@ -2,13 +2,6 @@
 
 public class FormattableStringExpressionProcessor : IExpressionStringParserProcessor
 {
-    private readonly IFormattableStringParser _parser;
-
-    public FormattableStringExpressionProcessor(IFormattableStringParser parser)
-    {
-        _parser = parser;
-    }
-
     public int Order => 400;
 
     public Result<object?> Process(ExpressionStringParserState state)
@@ -18,7 +11,9 @@ public class FormattableStringExpressionProcessor : IExpressionStringParserProce
         if (state.Input.StartsWith("=@\"") && state.Input.EndsWith("\""))
         {
             // =@"string value" -> literal, no functions but formattable strings possible
-            return Result<object?>.FromExistingResult(_parser.Parse(state.Input.Substring(3, state.Input.Length - 4), state.FormatProvider, state.Context));
+            return state.FormattableStringParser is not null
+                ? Result<object?>.FromExistingResult(state.FormattableStringParser.Parse(state.Input.Substring(3, state.Input.Length - 4), state.FormatProvider, state.Context))
+                : Result<object?>.Success(state.Input.Substring(3, state.Input.Length - 4));
         }
         else if (state.Input.StartsWith("=\"") && state.Input.EndsWith("\""))
         {

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/Operators/OperatorExpressionProcessorBase.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/Operators/OperatorExpressionProcessorBase.cs
@@ -20,13 +20,13 @@ public abstract class OperatorExpressionProcessorBase : IExpressionStringParserP
             return Result<object?>.Continue();
         }
 
-        var leftResult = state.Parser.Parse($"={split[0]}", state.FormatProvider, state.Context);
+        var leftResult = state.Parser.Parse($"={split[0]}", state.FormatProvider, state.Context, state.FormattableStringParser);
         if (!leftResult.IsSuccessful())
         {
             return leftResult;
         }
 
-        var rightResult = state.Parser.Parse($"={split[1]}", state.FormatProvider, state.Context);
+        var rightResult = state.Parser.Parse($"={split[1]}", state.FormatProvider, state.Context, state.FormattableStringParser);
         if (!rightResult.IsSuccessful())
         {
             return rightResult;

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/PipedExpressionProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/PipedExpressionProcessor.cs
@@ -13,7 +13,7 @@ public class PipedExpressionProcessor : IExpressionStringParserProcessor
             var resultValue = state.Context;
             foreach (var item in split)
             {
-                var result = state.Parser.Parse($"={item}", state.FormatProvider, resultValue);
+                var result = state.Parser.Parse($"={item}", state.FormatProvider, resultValue, state.FormattableStringParser);
                 if (!result.IsSuccessful())
                 {
                     return result;

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParserState.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParserState.cs
@@ -15,6 +15,10 @@ public class ExpressionStringParserState
         IExpressionStringParser parser,
         IFormattableStringParser? formattableStringParser)
     {
+        ArgumentGuard.IsNotNull(input, nameof(input));
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+        ArgumentGuard.IsNotNull(parser, nameof(parser));
+
         Input = input;
         FormatProvider = formatProvider;
         Context = context;

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParserState.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParserState.cs
@@ -6,12 +6,19 @@ public class ExpressionStringParserState
     public IFormatProvider FormatProvider { get; }
     public object? Context { get; }
     public IExpressionStringParser Parser { get; }
+    public IFormattableStringParser? FormattableStringParser { get; }
 
-    public ExpressionStringParserState(string input, IFormatProvider formatProvider, object? context, IExpressionStringParser parser)
+    public ExpressionStringParserState(
+        string input,
+        IFormatProvider formatProvider,
+        object? context,
+        IExpressionStringParser parser,
+        IFormattableStringParser? formattableStringParser)
     {
         Input = input;
         FormatProvider = formatProvider;
         Context = context;
         Parser = parser;
+        FormattableStringParser = formattableStringParser;
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/Extensions/ExpressionStringParserExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/ExpressionStringParserExtensions.cs
@@ -3,5 +3,8 @@
 public static class ExpressionStringParserExtensions
 {
     public static Result<object?> Parse(this IExpressionStringParser instance, string input, IFormatProvider formatProvider)
-        => instance.Parse(input, formatProvider, null);
+        => instance.Parse(input, formatProvider, null, null);
+
+    public static Result<object?> Parse(this IExpressionStringParser instance, string input, IFormatProvider formatProvider, IFormattableStringParser formattableStringParser)
+        => instance.Parse(input, formatProvider, null, formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/Extensions/FunctionParserExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/FunctionParserExtensions.cs
@@ -3,5 +3,8 @@
 public static class FunctionParserExtensions
 {
     public static Result<FunctionParseResult> Parse(this IFunctionParser instance, string input, IFormatProvider formatProvider)
-        => instance.Parse(input, formatProvider, null);
+        => instance.Parse(input, formatProvider, null, null);
+
+    public static Result<FunctionParseResult> Parse(this IFunctionParser instance, string input, IFormatProvider formatProvider, IFormattableStringParser formattableStringParser)
+        => instance.Parse(input, formatProvider, null, formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/ServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ public static class ServiceCollectionExtensions
         .AddScoped<IFormattableStringStateProcessor, CloseSignProcessor>()
         .AddScoped<IFormattableStringStateProcessor, PlaceholderProcessor>()
         .AddScoped<IFormattableStringStateProcessor, ResultProcessor>()
+        .AddScoped<IPlaceholderProcessor, ExpressionStringPlaceholderProcessor>()
         .AddScoped<IPlaceholderProcessor, UnknownPlaceholderProcessor>(); // used by CloseSignProcessor
 
     private static IServiceCollection AddMathematicExpressionParser(this IServiceCollection services)

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParser.cs
@@ -16,7 +16,7 @@ public class FormattableStringParser : IFormattableStringParser
     {
         input = ArgumentGuard.IsNotNull(input, nameof(input));
 
-        var state = new FormattableStringParserState(input, formatProvider, context);
+        var state = new FormattableStringParserState(input, formatProvider, context, this);
 
         for (var index = 0; index < input.Length; index++)
         {
@@ -25,7 +25,7 @@ public class FormattableStringParser : IFormattableStringParser
             foreach (var processor in _processors)
             {
                 var processorResult = processor.Process(state);
-                if (processorResult.Status != ResultStatus.NotSupported && !processorResult.IsSuccessful())
+                if (!processorResult.IsSuccessful())
                 {
                     return processorResult;
                 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParser.cs
@@ -9,12 +9,15 @@ public class FormattableStringParser : IFormattableStringParser
 
     public FormattableStringParser(IEnumerable<IFormattableStringStateProcessor> processors)
     {
+        ArgumentGuard.IsNotNull(processors, nameof(processors));
+
         _processors = processors;
     }
 
     public Result<string> Parse(string input, IFormatProvider formatProvider, object? context)
     {
         input = ArgumentGuard.IsNotNull(input, nameof(input));
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
 
         var state = new FormattableStringParserState(input, formatProvider, context, this);
 

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
@@ -5,6 +5,7 @@ public class FormattableStringParserState
     public string Input { get; }
     public IFormatProvider FormatProvider { get; }
     public object? Context { get; }
+    public IFormattableStringParser Parser { get; }
 
     public StringBuilder ResultBuilder { get; } = new();
     public StringBuilder PlaceholderBuilder { get; } = new();
@@ -13,11 +14,12 @@ public class FormattableStringParserState
     public int Index { get; private set; }
     public bool IsEscaped { get; private set; }
 
-    public FormattableStringParserState(string input, IFormatProvider formatProvider, object? context)
+    public FormattableStringParserState(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser parser)
     {
         Input = input;
         FormatProvider = formatProvider;
         Context = context;
+        Parser = parser;
     }
 
     public bool NextPositionIsSign(char sign)

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
@@ -16,6 +16,10 @@ public class FormattableStringParserState
 
     public FormattableStringParserState(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser parser)
     {
+        ArgumentGuard.IsNotNull(input, nameof(input));
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+        ArgumentGuard.IsNotNull(parser, nameof(parser));
+
         Input = input;
         FormatProvider = formatProvider;
         Context = context;
@@ -59,6 +63,8 @@ public class FormattableStringParserState
 
     public void ClosePlaceholder(string value)
     {
+        ArgumentGuard.IsNotNull(value, nameof(value));
+
         InPlaceholder = false;
         ResultBuilder.Append(value);
         PlaceholderBuilder.Clear();

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/CloseSignProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/CloseSignProcessor.cs
@@ -15,7 +15,7 @@ public class CloseSignProcessor : IFormattableStringStateProcessor
 
         if (state.Current != FormattableStringParser.CloseSign)
         {
-            return Result<string>.NotSupported();
+            return Result<string>.Continue();
         }
 
         if (state.NextPositionIsSign(FormattableStringParser.CloseSign)
@@ -36,7 +36,7 @@ public class CloseSignProcessor : IFormattableStringStateProcessor
 
         var placeholderResult = _processors
             .OrderBy(x => x.Order)
-            .Select(x => x.Process(state.PlaceholderBuilder.ToString(), state.FormatProvider, state.Context))
+            .Select(x => x.Process(state.PlaceholderBuilder.ToString(), state.FormatProvider, state.Context, state.Parser))
             .FirstOrDefault(x => x.Status != ResultStatus.Continue)
                 ?? Result<string>.Invalid($"Unknown placeholder in value: {state.PlaceholderBuilder}");
 

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/OpenSignProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/OpenSignProcessor.cs
@@ -8,7 +8,7 @@ public class OpenSignProcessor : IFormattableStringStateProcessor
 
         if (state.Current != FormattableStringParser.OpenSign)
         {
-            return Result<string>.NotSupported();
+            return Result<string>.Continue();
         }
 
         if (state.NextPositionIsSign(FormattableStringParser.OpenSign)

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/PlaceholderProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/PlaceholderProcessor.cs
@@ -8,7 +8,7 @@ public class PlaceholderProcessor : IFormattableStringStateProcessor
 
         if (!state.InPlaceholder)
         {
-            return Result<string>.NotSupported();
+            return Result<string>.Continue();
         }
 
         state.PlaceholderBuilder.Append(state.Current);

--- a/src/CrossCutting.Utilities.Parsers/FunctionParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParser.cs
@@ -15,7 +15,7 @@ public class FunctionParser : IFunctionParser
         _argumentProcessors = argumentProcessors;
     }
 
-    public Result<FunctionParseResult> Parse(string input, IFormatProvider formatProvider, object? context)
+    public Result<FunctionParseResult> Parse(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
     {
         if (string.IsNullOrEmpty(input))
         {
@@ -53,7 +53,7 @@ public class FunctionParser : IFunctionParser
             var stringArguments = remainder.Substring(openIndex.Value + 1, closeIndex.Value - openIndex.Value - 1);
             var stringArgumentsSplit = stringArguments.SplitDelimited(',', '\"', trimItems: true);
             var arguments = new List<FunctionParseResultArgument>();
-            var addArgumentsResult = AddArguments(results, stringArgumentsSplit, arguments, formatProvider, context);
+            var addArgumentsResult = AddArguments(results, stringArgumentsSplit, arguments, formatProvider, context, formattableStringParser);
             if (!addArgumentsResult.IsSuccessful())
             {
                 return addArgumentsResult;
@@ -96,7 +96,7 @@ public class FunctionParser : IFunctionParser
         }
     }
 
-    private Result<FunctionParseResult> AddArguments(List<FunctionParseResult> results, string[] stringArgumentsSplit, List<FunctionParseResultArgument> arguments, IFormatProvider formatProvider, object? context)
+    private Result<FunctionParseResult> AddArguments(List<FunctionParseResult> results, string[] stringArgumentsSplit, List<FunctionParseResultArgument> arguments, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
     {
         foreach (var stringArgument in stringArgumentsSplit)
         {
@@ -108,7 +108,7 @@ public class FunctionParser : IFunctionParser
 
             var processValueResult = _argumentProcessors
                 .OrderBy(x => x.Order)
-                .Select(x => x.Process(stringArgument, results, formatProvider, context))
+                .Select(x => x.Process(stringArgument, results, formatProvider, context, formattableStringParser))
                 .FirstOrDefault(x => x.Status != ResultStatus.Continue);
             if (processValueResult is not null)
             {

--- a/src/CrossCutting.Utilities.Parsers/FunctionParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParser.cs
@@ -11,12 +11,17 @@ public class FunctionParser : IFunctionParser
         IEnumerable<IFunctionParserNameProcessor> nameProcessors,
         IEnumerable<IFunctionParserArgumentProcessor> argumentProcessors)
     {
+        ArgumentGuard.IsNotNull(nameProcessors, nameof(nameProcessors));
+        ArgumentGuard.IsNotNull(argumentProcessors, nameof(argumentProcessors));
+
         _nameProcessors = nameProcessors;
         _argumentProcessors = argumentProcessors;
     }
 
     public Result<FunctionParseResult> Parse(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
     {
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+
         if (string.IsNullOrEmpty(input))
         {
             return Result<FunctionParseResult>.NotFound("Input cannot be null or empty");

--- a/src/CrossCutting.Utilities.Parsers/FunctionParserArgumentProcessors/FormattableStringFunctionParserArgumentProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParserArgumentProcessors/FormattableStringFunctionParserArgumentProcessor.cs
@@ -2,22 +2,15 @@
 
 public class FormattableStringFunctionParserArgumentProcessor : IFunctionParserArgumentProcessor
 {
-    private readonly IFormattableStringParser _parser;
-
     public int Order => 10;
 
-    public FormattableStringFunctionParserArgumentProcessor(IFormattableStringParser parser)
-    {
-        _parser = parser;
-    }
-
-    public Result<FunctionParseResultArgument> Process(string stringArgument, IReadOnlyCollection<FunctionParseResult> results, IFormatProvider formatProvider, object? context)
+    public Result<FunctionParseResultArgument> Process(string stringArgument, IReadOnlyCollection<FunctionParseResult> results, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
     {
         stringArgument = ArgumentGuard.IsNotNull(stringArgument, nameof(stringArgument));
 
-        if (stringArgument.StartsWith("@"))
+        if (stringArgument.StartsWith("@") && formattableStringParser is not null)
         {
-            var result = _parser.Parse(stringArgument.Substring(1), formatProvider, context);
+            var result = formattableStringParser.Parse(stringArgument.Substring(1), formatProvider, context);
             return result.IsSuccessful()
                 ? Result<FunctionParseResultArgument>.Success(new LiteralArgument(result.Value!))
                 : Result<FunctionParseResultArgument>.FromExistingResult(result);

--- a/src/CrossCutting.Utilities.Parsers/MathematicExpressionParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/MathematicExpressionParser.cs
@@ -9,15 +9,25 @@ public class MathematicExpressionParser : IMathematicExpressionParser
 
     public MathematicExpressionParser(IExpressionParser expressionParser, IEnumerable<IMathematicExpressionProcessor> processors)
     {
+        ArgumentGuard.IsNotNull(expressionParser, nameof(expressionParser));
+        ArgumentGuard.IsNotNull(processors, nameof(processors));
+
         _expressionParser = expressionParser;
         _processors = processors;
     }
 
     internal static bool IsMathematicExpression(string found)
-        => Array.Exists(MathematicOperators.Aggregators, x => found.Contains(x.Character.ToString()));
+    {
+        ArgumentGuard.IsNotNull(found, nameof(found));
+
+        return Array.Exists(MathematicOperators.Aggregators, x => found.Contains(x.Character.ToString()));
+    }
 
     public Result<object?> Parse(string input, IFormatProvider formatProvider, object? context)
     {
+        ArgumentGuard.IsNotNull(input, nameof(input));
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+
         var state = new MathematicExpressionState(input, formatProvider, context, Parse);
         var error = _processors
             .Select(x => x.Process(state))

--- a/src/CrossCutting.Utilities.Parsers/MathematicExpressionState.cs
+++ b/src/CrossCutting.Utilities.Parsers/MathematicExpressionState.cs
@@ -24,6 +24,10 @@ public class MathematicExpressionState
         object? context,
         Func<string, IFormatProvider, object?, Result<object?>> parseDelegate)
     {
+        ArgumentGuard.IsNotNull(input, nameof(input));
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+        ArgumentGuard.IsNotNull(parseDelegate, nameof(parseDelegate));
+
         Input = input;
         FormatProvider = formatProvider;
         Context = context;

--- a/src/CrossCutting.Utilities.Parsers/ParseResult.cs
+++ b/src/CrossCutting.Utilities.Parsers/ParseResult.cs
@@ -28,6 +28,9 @@ public class ParseResult<TKey, TValue>
 
     internal ParseResult(bool isSuccessful, IEnumerable<string> errorMessages, IEnumerable<KeyValuePair<TKey, TValue>> values)
     {
+        ArgumentGuard.IsNotNull(errorMessages, nameof(errorMessages));
+        ArgumentGuard.IsNotNull(values, nameof(values));
+
         IsSuccessful = isSuccessful;
         ErrorMessages = errorMessages;
         Values = values;

--- a/src/CrossCutting.Utilities.Parsers/PipeDelimitedDataTableParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/PipeDelimitedDataTableParser.cs
@@ -30,6 +30,8 @@ public static class PipeDelimitedDataTableParser
         IEnumerable<string>? columnNames = null,
         Func<string, string, object>? transformFunction = null)
     {
+        ArgumentGuard.IsNotNull(input, nameof(input));
+
         using (var sr = new StringReader(input))
         {
             string line;

--- a/src/CrossCutting.Utilities.Parsers/PlaceholderProcessors/ExpressionStringPlaceholderProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/PlaceholderProcessors/ExpressionStringPlaceholderProcessor.cs
@@ -1,0 +1,29 @@
+﻿namespace CrossCutting.Utilities.Parsers.PlaceholderProcessors;
+
+public class ExpressionStringPlaceholderProcessor : IPlaceholderProcessor
+{
+    private readonly IExpressionStringParser _expressionStringParser;
+
+    public ExpressionStringPlaceholderProcessor(IExpressionStringParser expressionStringParser)
+    {
+        ArgumentGuard.IsNotNull(expressionStringParser, nameof(expressionStringParser));
+
+        _expressionStringParser = expressionStringParser;
+    }
+
+    public int Order => 990;
+
+    public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+    {
+        var result = _expressionStringParser.Parse($"={value}", formatProvider, context, formattableStringParser);
+
+        if (result.Status == ResultStatus.NotFound)
+        {
+            return Result<string>.Continue();
+        }
+
+        return Result<string>.FromExistingResult(
+            result,
+            value => value.ToString(formatProvider, string.Empty));
+    }
+}

--- a/src/CrossCutting.Utilities.Parsers/PlaceholderProcessors/UnknownPlaceholderProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/PlaceholderProcessors/UnknownPlaceholderProcessor.cs
@@ -4,6 +4,6 @@ public class UnknownPlaceholderProcessor : IPlaceholderProcessor
 {
     public int Order => 1000;
 
-    public Result<string> Process(string value, IFormatProvider formatProvider, object? context)
+    public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
         => Result<string>.NotSupported($"Unknown placeholder in value: {value}");
 }

--- a/src/CrossCutting.Utilities.Parsers/StringFormatParserState.cs
+++ b/src/CrossCutting.Utilities.Parsers/StringFormatParserState.cs
@@ -16,6 +16,8 @@ internal sealed class StringFormatParserState
 
     public StringFormatParserState(IEnumerable<object> args)
     {
+        ArgumentGuard.IsNotNull(args, nameof(args));
+
         FormatValues = new List<object>(args.ToList());
     }
 


### PR DESCRIPTION
Like the title says: You can now use expression in formattable strings.

Example:
I can add 1 to 2, this results in {1 + 1}