### PR TITLE
Small improvements

### DIFF
--- a/src/CrossCutting.Utilities.Parsers.Tests/Extensions/ExpressionStringParserExtensionsTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/Extensions/ExpressionStringParserExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿namespace CrossCutting.Utilities.Parsers.Tests.Extensions;
+
+public class ExpressionStringParserExtensionsTests
+{
+    private Mock<IExpressionStringParser> SutMock { get; } = new();
+    private Mock<IFormattableStringParser> FormattableStringParserMock { get; } = new();
+    private const string Input = "Some input";
+    private object Context { get; } = new object();
+    private IFormatProvider FormatProvider { get; } = CultureInfo.InvariantCulture;
+    
+    [Fact]
+    public void Parse_Without_Context_And_FormattableStringParser_Gets_Processed_Correctly()
+    {
+        // Act
+        _ = SutMock.Object.Parse(Input, FormatProvider);
+
+        // Assert
+        SutMock.Verify(x => x.Parse(Input, FormatProvider, null, null), Times.Once);
+    }
+
+    [Fact]
+    public void Parse_Without_Context_Gets_Processed_Correctly()
+    {
+        // Act
+        _ = SutMock.Object.Parse(Input, FormatProvider, FormattableStringParserMock.Object);
+
+        // Assert
+        SutMock.Verify(x => x.Parse(Input, FormatProvider, null, FormattableStringParserMock.Object), Times.Once);
+    }
+
+    [Fact]
+    public void Parse_Without_FormattableStringParser_Gets_Processed_Correctly()
+    {
+        // Act
+        _ = SutMock.Object.Parse(Input, FormatProvider, Context);
+
+        // Assert
+        SutMock.Verify(x => x.Parse(Input, FormatProvider, Context, null), Times.Once);
+    }
+}

--- a/src/CrossCutting.Utilities.Parsers.Tests/Extensions/FunctionParserExtensionsTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/Extensions/FunctionParserExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿namespace CrossCutting.Utilities.Parsers.Tests.Extensions;
+
+public class FunctionParserExtensionsTests
+{
+    private Mock<IFunctionParser> SutMock { get; } = new();
+    private Mock<IFormattableStringParser> FormattableStringParserMock { get; } = new();
+    private const string Input = "Some input";
+    private object Context { get; } = new object();
+    private IFormatProvider FormatProvider { get; } = CultureInfo.InvariantCulture;
+
+    [Fact]
+    public void Parse_Without_Context_And_FormattableStringParser_Gets_Processed_Correctly()
+    {
+        // Act
+        _ = SutMock.Object.Parse(Input, FormatProvider);
+
+        // Assert
+        SutMock.Verify(x => x.Parse(Input, FormatProvider, null, null), Times.Once);
+    }
+
+    [Fact]
+    public void Parse_Without_Context_Gets_Processed_Correctly()
+    {
+        // Act
+        _ = SutMock.Object.Parse(Input, FormatProvider, FormattableStringParserMock.Object);
+
+        // Assert
+        SutMock.Verify(x => x.Parse(Input, FormatProvider, null, FormattableStringParserMock.Object), Times.Once);
+    }
+
+    [Fact]
+    public void Parse_Without_FormattableStringParser_Gets_Processed_Correctly()
+    {
+        // Act
+        _ = SutMock.Object.Parse(Input, FormatProvider, Context);
+
+        // Assert
+        SutMock.Verify(x => x.Parse(Input, FormatProvider, Context, null), Times.Once);
+    }
+}

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
@@ -50,6 +50,23 @@ public sealed class FunctionParserTests : IDisposable
     }
 
     [Fact]
+    public void Can_Parse_Single_Function_With_Quoted_Arguments_That_Are_Surrounded_With_Spaces()
+    {
+        // Arrange
+        var input = "MYFUNCTION(\"  a,b  \",c)";
+
+        // Act
+        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.FunctionName.Should().Be("MYFUNCTION");
+        result.Value.Arguments.Should().HaveCount(2);
+        result.Value.Arguments.Should().AllBeOfType<LiteralArgument>();
+        result.Value.Arguments.OfType<LiteralArgument>().Select(x => x.Value).Should().BeEquivalentTo("  a,b  ", "c");
+    }
+
+    [Fact]
     public void Can_Parse_Single_Function_With_FormattableString_Argument()
     {
         // Arrange
@@ -64,6 +81,23 @@ public sealed class FunctionParserTests : IDisposable
         result.Value.Arguments.Should().HaveCount(3);
         result.Value.Arguments.Should().AllBeOfType<LiteralArgument>();
         result.Value.Arguments.OfType<LiteralArgument>().Select(x => x.Value).Should().BeEquivalentTo("Hello, replaced name!", "b", "c");
+    }
+
+    [Fact]
+    public void Can_Parse_Single_Function_With_FormattableString_Argument_That_Are_Surrounded_With_Spaces()
+    {
+        // Arrange
+        var input = "MYFUNCTION(@\"  Hello, {Name}!  \",b,c)";
+
+        // Act
+        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.FunctionName.Should().Be("MYFUNCTION");
+        result.Value.Arguments.Should().HaveCount(3);
+        result.Value.Arguments.Should().AllBeOfType<LiteralArgument>();
+        result.Value.Arguments.OfType<LiteralArgument>().Select(x => x.Value).Should().BeEquivalentTo("  Hello, replaced name!  ", "b", "c");
     }
 
     [Fact]
@@ -337,6 +371,23 @@ public sealed class FunctionParserTests : IDisposable
         result.Value.Arguments.Should().HaveCount(3);
         result.Value.Arguments.Should().AllBeOfType<LiteralArgument>();
         result.Value.Arguments.OfType<LiteralArgument>().Select(x => x.Value).Should().BeEquivalentTo("a", "b", "c");
+    }
+
+    [Fact]
+    public void Parse_With_Spaces_In_Quoted_Arguments_Does_Not_Strip_Spaces()
+    {
+        // Arrange
+        var input = "MYFUNCTION(\"a \",\" b \",\" c\")";
+
+        // Act
+        var result = CreateSut().Parse(input, CultureInfo.InvariantCulture);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.FunctionName.Should().Be("MYFUNCTION");
+        result.Value.Arguments.Should().HaveCount(3);
+        result.Value.Arguments.Should().AllBeOfType<LiteralArgument>();
+        result.Value.Arguments.OfType<LiteralArgument>().Select(x => x.Value).Should().BeEquivalentTo("a ", " b ", " c");
     }
 
     public void Dispose()

--- a/src/CrossCutting.Utilities.Parsers/Extensions/ExpressionStringParserExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/ExpressionStringParserExtensions.cs
@@ -7,4 +7,7 @@ public static class ExpressionStringParserExtensions
 
     public static Result<object?> Parse(this IExpressionStringParser instance, string input, IFormatProvider formatProvider, IFormattableStringParser formattableStringParser)
         => instance.Parse(input, formatProvider, null, formattableStringParser);
+
+    public static Result<object?> Parse(this IExpressionStringParser instance, string input, IFormatProvider formatProvider, object? context)
+        => instance.Parse(input, formatProvider, context, null);
 }

--- a/src/CrossCutting.Utilities.Parsers/Extensions/FunctionParserExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/FunctionParserExtensions.cs
@@ -7,4 +7,7 @@ public static class FunctionParserExtensions
 
     public static Result<FunctionParseResult> Parse(this IFunctionParser instance, string input, IFormatProvider formatProvider, IFormattableStringParser formattableStringParser)
         => instance.Parse(input, formatProvider, null, formattableStringParser);
+
+    public static Result<FunctionParseResult> Parse(this IFunctionParser instance, string input, IFormatProvider formatProvider, object? context)
+        => instance.Parse(input, formatProvider, context, null);
 }


### PR DESCRIPTION
- Change/fix: Function arguments are now not stripped when items are wrapped in text qualifiers (double quotes)
- Minor: Added convencience overloads for Parse extension methods on ExpressionStringParser and FunctionParser to include the context, but exclude the IFormattableStringParser. Added missing unit tests for these extension methods.