### PR TITLE
Small improvements

### DIFF
--- a/src/CrossCutting.Data.Abstractions.Tests/Extensions/ObjectExtensionsTests.cs
+++ b/src/CrossCutting.Data.Abstractions.Tests/Extensions/ObjectExtensionsTests.cs
@@ -4,10 +4,10 @@ public class ObjectExtensionsTests
 {
     [Theory]
     [MemberData(nameof(FixDbNullData))]
-    public void FixDbNull_Returns_Correct_Value(object input, object expectedOutput)
+    public void FixDbNull_Returns_Correct_Value(object? input, object? expectedOutput)
     {
         // Act
-        var actual = input.FixDbNull();
+        var actual = input!.FixDbNull();
 
         // Asset
         actual.Should().Be(expectedOutput);
@@ -15,7 +15,7 @@ public class ObjectExtensionsTests
 
     [Theory]
     [MemberData(nameof(FixNullData))]
-    public void FixNull_Returns_Correct_Value(object input, object expectedOutput)
+    public void FixNull_Returns_Correct_Value(object? input, object expectedOutput)
     {
         // Act
         var actual = input.FixNull();
@@ -24,26 +24,26 @@ public class ObjectExtensionsTests
         actual.Should().Be(expectedOutput);
     }
 
-    public static IEnumerable<object?[]> FixDbNullData
-        => new List<object?[]>
+    public static TheoryData<object?, object?> FixDbNullData
+        => new TheoryData<object?, object?>
         {
-                new object?[] { DBNull.Value, null },
-                new object?[] { null, null },
-                new object?[] { "", "" },
-                new object?[] { "test", "test" },
-                new object?[] { 1, 1 },
-                new object?[] { false, false },
-                new object?[] { new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified) },
+            { DBNull.Value, null },
+            { null, null }, // note that according to the interface, you can't send null. but it will not crash 8-)
+            { "", "" },
+            { "test", "test" },
+            { 1, 1 },
+            { false, false },
+            { new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified) },
         };
 
-    public static IEnumerable<object?[]> FixNullData
-        => new List<object?[]>
+    public static TheoryData<object?, object> FixNullData
+        => new TheoryData<object?, object>
         {
-                new object?[] { null, DBNull.Value },
-                new object?[] { "", "" },
-                new object?[] { "test", "test" },
-                new object?[] { 1, 1 },
-                new object?[] { false, false },
-                new object?[] { new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified) },
+            { null, DBNull.Value },
+            { "", "" },
+            { "test", "test" },
+            { 1, 1 },
+            { false, false },
+            { new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified), new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified) },
         };
 }

--- a/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
+++ b/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.ProcessingPipeline</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.3.0</Version>
-    <PackageVersion>3.3.0</PackageVersion>
+    <Version>4.0.0</Version>
+    <PackageVersion>4.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.ProcessingPipeline/IPipeline.cs
+++ b/src/CrossCutting.ProcessingPipeline/IPipeline.cs
@@ -2,10 +2,14 @@
 
 public interface IPipeline<TModel>
 {
+    IReadOnlyCollection<IPipelineFeature<TModel>> Features { get; }
+    
     Result<TModel> Process(TModel model);
 }
 
 public interface IPipeline<TModel, TContext>
 {
+    IReadOnlyCollection<IPipelineFeature<TModel, TContext>> Features { get; }
+
     Result<TModel> Process(TModel model, TContext context);
 }

--- a/src/CrossCutting.ProcessingPipeline/IPipelineBuilder.cs
+++ b/src/CrossCutting.ProcessingPipeline/IPipelineBuilder.cs
@@ -2,10 +2,10 @@
 
 public interface IPipelineBuilder<TModel> : IValidatableObject
 {
-    public Pipeline<TModel> Build();
+    public IPipeline<TModel> Build();
 }
 
 public interface IPipelineBuilder<TModel, TContext> : IValidatableObject
 {
-    public Pipeline<TModel, TContext> Build();
+    public IPipeline<TModel, TContext> Build();
 }

--- a/src/CrossCutting.ProcessingPipeline/PipelineBuilder.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineBuilder.cs
@@ -10,7 +10,7 @@ public class PipelineBuilder<TModel> : PipelineBuilderBase<IPipelineFeature<TMod
     {
     }
 
-    public Pipeline<TModel> Build()
+    public IPipeline<TModel> Build()
         => new Pipeline<TModel>(Initialize, Features.Select(x => x.Build()));
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
@@ -32,7 +32,7 @@ public class PipelineBuilder<TModel, TContext> : PipelineBuilderBase<IPipelineFe
     {
     }
 
-    public Pipeline<TModel, TContext> Build()
+    public IPipeline<TModel, TContext> Build()
         => new Pipeline<TModel, TContext>(Initialize, Features.Select(x => x.Build()));
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)


### PR DESCRIPTION
- Interfaces of Pipelines should not have members pointing to concrete types. Use interfaces instead. -> note that this is a breaking change in the interface, so the major version number has been increased from 3 to 4)
- Fixed code analysis warnings in unit tests (use strongly-typed TheoryData)