### PR TITLE
vnext

### DIFF
--- a/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
+++ b/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.8.0" />
-    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="0.9.2" />
+    <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.9.3" />
+    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="0.9.3" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
+++ b/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CrossCutting.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/CrossCutting.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -224,4 +224,22 @@ public class EnumerableExtensionsTests
         // Assert
         result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
     }
+    
+    [Fact]
+    public async Task SelectAsync_Returns_Correct_Result()
+    {
+        // Arrange
+        var input = new string[] { "a", "b", "c" };
+
+        // Act
+        var result = await input.SelectAsync(MyAsyncFunction);
+
+        // Assert
+        result.Should().BeEquivalentTo("A", "B", "C");
+    }
+
+    private Task<string> MyAsyncFunction(string input)
+    {
+        return Task.FromResult(input.ToUpperInvariant());
+    }
 }

--- a/src/CrossCutting.Common.Tests/GlobalUsings.cs
+++ b/src/CrossCutting.Common.Tests/GlobalUsings.cs
@@ -4,6 +4,7 @@ global using System.Collections.ObjectModel;
 global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Linq;
+global using System.Threading.Tasks;
 global using CrossCutting.Common.DataAnnotations;
 global using CrossCutting.Common.Extensions;
 global using CrossCutting.Common.Results;

--- a/src/CrossCutting.Common.Tests/Results/ResultTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/ResultTests.cs
@@ -1032,7 +1032,7 @@ public class ResultTests
     }
 
     [Fact]
-    public void TryCast_Returns_Invalid_Without_ErrorMessage_When_Value_Could_Not_Be_Cast()
+    public void TryCast_Returns_Invalid_With_Default_ErrorMessage_When_Value_Could_Not_Be_Cast()
     {
         // Arrange
         var sut = Result.Success<object?>("test");
@@ -1042,11 +1042,11 @@ public class ResultTests
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ErrorMessage.Should().BeNull();
+        result.ErrorMessage.Should().Be("Could not cast System.Object to System.Boolean");
     }
 
     [Fact]
-    public void TryCast_Returns_Invalid_With_ErrorMessage_When_Value_Could_Not_Be_Cast()
+    public void TryCast_Returns_Invalid_With_Custom_ErrorMessage_When_Value_Could_Not_Be_Cast()
     {
         // Arrange
         var sut = Result.Success<object?>("test");

--- a/src/CrossCutting.Common.Tests/Results/ResultTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/ResultTests.cs
@@ -1103,6 +1103,20 @@ public class ResultTests
     }
 
     [Fact]
+    public void TryCast_Returns_Same_Status()
+    {
+        // Arrange
+        var sut = Result.Continue<object?>(true);
+
+        // Act
+        var result = sut.TryCast<bool>();
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Continue);
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
     public void Can_Create_ValidationResult_With_ErrorMessage_From_ValidationErrors()
     {
         // Arrange

--- a/src/CrossCutting.Common.Tests/Results/ResultTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/ResultTests.cs
@@ -1223,4 +1223,32 @@ public class ResultTests
         act.Should().ThrowExactly<InvalidOperationException>().WithMessage("Result: Error, ErrorMessage: Kaboom");
     }
 
+    [Fact]
+    public void Transform_Can_Transform_The_Value_On_Success()
+    {
+        // Arrange
+        var source = Result.Success(1);
+
+        // Act
+        var result = source.Transform(x => x.ToString());
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be("1");
+    }
+
+    [Fact]
+    public void Transform_Returns_Same_Error_On_Failure()
+    {
+        // Arrange
+        var source = Result.Error<int>("Kaboom!");
+
+        // Act
+        var result = source.Transform(x => x.ToString());
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Kaboom!");
+        result.Value.Should().BeNull();
+    }
 }

--- a/src/CrossCutting.Common.Tests/Results/ResultTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/ResultTests.cs
@@ -1224,13 +1224,13 @@ public class ResultTests
     }
 
     [Fact]
-    public void Transform_Can_Transform_The_Value_On_Success()
+    public void TransformValue_Can_TransformValue_The_Value_On_Success()
     {
         // Arrange
         var source = Result.Success(1);
 
         // Act
-        var result = source.Transform(x => x.ToString());
+        var result = source.TransformValue(x => x.ToString());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -1238,13 +1238,13 @@ public class ResultTests
     }
 
     [Fact]
-    public void Transform_Returns_Same_Error_On_Failure()
+    public void TransformValue_Returns_Same_Error_On_Failure()
     {
         // Arrange
         var source = Result.Error<int>("Kaboom!");
 
         // Act
-        var result = source.Transform(x => x.ToString());
+        var result = source.TransformValue(x => x.ToString());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Error);

--- a/src/CrossCutting.Common/CrossCutting.Common.csproj
+++ b/src/CrossCutting.Common/CrossCutting.Common.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Common</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.8.0</Version>
-    <PackageVersion>3.8.0</PackageVersion>
+    <Version>3.9.0</Version>
+    <PackageVersion>3.9.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Common/Extensions/EnumerableExtensions.cs
+++ b/src/CrossCutting.Common/Extensions/EnumerableExtensions.cs
@@ -76,4 +76,30 @@ public static class EnumerableExtensions
             ? result
             : defaultDelegate(result);
     }
+
+    public static async Task<IEnumerable<TResult>> SelectAsync<TSource, TResult>(
+        this IEnumerable<TSource> source, Func<TSource, Task<TResult>> method,
+        int concurrency = int.MaxValue)
+    {
+        var semaphore = new SemaphoreSlim(concurrency);
+        try
+        {
+            return await Task.WhenAll(source.Select(async s =>
+            {
+                try
+                {
+                    await semaphore.WaitAsync().ConfigureAwait(false);
+                    return await method(s).ConfigureAwait(false);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            })).ConfigureAwait(false);
+        }
+        finally
+        {
+            semaphore.Dispose();
+        }
+    }
 }

--- a/src/CrossCutting.Common/Extensions/ObjectExtensions.cs
+++ b/src/CrossCutting.Common/Extensions/ObjectExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CrossCutting.Common.Extensions;
+﻿namespace CrossCutting.Common.Extensions;
 
 public static class ObjectExtensions
 {

--- a/src/CrossCutting.Common/GlobalUsings.cs
+++ b/src/CrossCutting.Common/GlobalUsings.cs
@@ -11,6 +11,8 @@ global using System.Linq;
 global using System.Runtime.CompilerServices;
 global using System.Text;
 global using System.Text.RegularExpressions;
+global using System.Threading;
+global using System.Threading.Tasks;
 global using CrossCutting.Common.Abstractions;
 global using CrossCutting.Common.Extensions;
 global using CrossCutting.Common.Results;

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -38,9 +38,7 @@ public record Result<T> : Result
 
         if (Value is not TCast castValue)
         {
-            return errorMessage is null
-                ? Invalid<TCast>()
-                : Invalid<TCast>(errorMessage);
+            return Invalid<TCast>(errorMessage ?? $"Could not cast {typeof(T).FullName} to {typeof(TCast).FullName}");
         }
 
         return new Result<TCast>(castValue, Status, ErrorMessage, ValidationErrors, Exception);

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -44,7 +44,7 @@ public record Result<T> : Result
         return new Result<TCast>(castValue, Status, ErrorMessage, ValidationErrors, Exception);
     }
 
-    public Result<TTarget> Transform<TTarget>(Func<T, TTarget> transformDelegate)
+    public Result<TTarget> TransformValue<TTarget>(Func<T, TTarget> transformDelegate)
     {
         ArgumentGuard.IsNotNull(transformDelegate, nameof(transformDelegate));
 

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -43,7 +43,7 @@ public record Result<T> : Result
                 : Invalid<TCast>(errorMessage);
         }
 
-        return Success(castValue);
+        return new Result<TCast>(castValue, Status, ErrorMessage, ValidationErrors, Exception);
     }
 }
 

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -45,6 +45,18 @@ public record Result<T> : Result
 
         return new Result<TCast>(castValue, Status, ErrorMessage, ValidationErrors, Exception);
     }
+
+    public Result<TTarget> Transform<TTarget>(Func<T, TTarget> transformDelegate)
+    {
+        ArgumentGuard.IsNotNull(transformDelegate, nameof(transformDelegate));
+
+        if (!IsSuccessful())
+        {
+            return FromExistingResult<TTarget>(this);
+        }
+
+        return new Result<TTarget>(transformDelegate(Value!), Status, ErrorMessage, ValidationErrors, Exception);
+    }
 }
 
 public record Result

--- a/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
+++ b/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
@@ -13,12 +13,12 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.7.0">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
+++ b/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
@@ -14,12 +14,12 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.7.0">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
+++ b/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Data.Core</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.8.0</Version>
-    <PackageVersion>3.8.0</PackageVersion>
+    <Version>3.9.0</Version>
+    <PackageVersion>3.9.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
+++ b/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.7.0">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Data.Sql.Tests/DatabaseCommandProcessorTests.cs
+++ b/src/CrossCutting.Data.Sql.Tests/DatabaseCommandProcessorTests.cs
@@ -1,6 +1,4 @@
-﻿using NSubstitute;
-
-namespace CrossCutting.Data.Sql.Tests;
+﻿namespace CrossCutting.Data.Sql.Tests;
 
 public sealed class DatabaseCommandProcessorTests : IDisposable
 {

--- a/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
+++ b/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
+++ b/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.DataTableDumper</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.8.0</Version>
-    <PackageVersion>3.8.0</PackageVersion>
+    <Version>3.9.0</Version>
+    <PackageVersion>3.9.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.ProcessingPipeline.Tests/CrossCutting.ProcessingPipeline.Tests.csproj
+++ b/src/CrossCutting.ProcessingPipeline.Tests/CrossCutting.ProcessingPipeline.Tests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CrossCutting.ProcessingPipeline.Tests/GlobalUsings.cs
+++ b/src/CrossCutting.ProcessingPipeline.Tests/GlobalUsings.cs
@@ -1,4 +1,6 @@
-﻿global using CrossCutting.Common.Results;
+﻿global using System.ComponentModel.DataAnnotations;
+global using CrossCutting.Common.Extensions;
+global using CrossCutting.Common.Results;
 global using FluentAssertions;
 global using Microsoft.Extensions.DependencyInjection;
 global using Xunit;

--- a/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
+++ b/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
@@ -400,7 +400,7 @@ public class ProofOfConceptTests
         }
     }
 
-    public class PipelineComponent_With_Context()
+    public class PipelineComponent_Without_Context()
     {
         [Fact]
         public async Task Can_Call_Process_Without_CancellationToken()
@@ -417,13 +417,13 @@ public class ProofOfConceptTests
         }
     }
 
-    public class PipelineComponent_Without_Context()
+    public class PipelineComponent_With_Context()
     {
         [Fact]
         public async Task Can_Call_Process_Without_CancellationToken()
         {
             // Arrange
-            var sut = new MyReplacedContextlessComponent();
+            var sut = new MyReplacedComponentWithContext();
             var context = new PipelineContext<object?, object?>(1, 2);
 
             // Act

--- a/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
+++ b/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace CrossCutting.ProcessingPipeline.Tests;
+﻿namespace CrossCutting.ProcessingPipeline.Tests;
 
 public class ProofOfConceptTests
 {
@@ -92,9 +90,10 @@ public class ProofOfConceptTests
         {
             // Arrange
             var builder = new PipelineBuilder<object?, object?> { Components = null! };
+            var validationResults = new List<ValidationResult>();
 
             // Act
-            var validationResults = builder.Validate(new(builder));
+            _ = builder.TryValidate(validationResults);
 
             // Assert
             validationResults.Should().ContainSingle();
@@ -105,9 +104,10 @@ public class ProofOfConceptTests
         {
             // Arrange
             var builder = new PipelineBuilder<object?, object?> { Components = new List<IBuilder<IPipelineComponent<object?, object?>>>() };
+            var validationResults = new List<ValidationResult>();
 
             // Act
-            var validationResults = builder.Validate(new(builder));
+            _ = builder.TryValidate(validationResults);
 
             // Assert
             validationResults.Should().BeEmpty();
@@ -118,9 +118,10 @@ public class ProofOfConceptTests
         {
             // Arrange
             var builder = new PipelineBuilder<object?, object?> { Components = new List<IBuilder<IPipelineComponent<object?, object?>>>(new[] { new MyComponentWithContextBuilder() }) };
+            var validationResults = new List<ValidationResult>();
 
             // Act
-            var validationResults = builder.Validate(new(builder));
+            _ = builder.TryValidate(validationResults);
 
             // Assert
             validationResults.Should().BeEmpty();
@@ -268,9 +269,10 @@ public class ProofOfConceptTests
         {
             // Arrange
             var builder = new PipelineBuilder<object?> { Components = null! };
+            var validationResults = new List<ValidationResult>();
 
             // Act
-            var validationResults = builder.Validate(new(builder));
+            _ = builder.TryValidate(validationResults);
 
             // Assert
             validationResults.Should().ContainSingle();
@@ -281,9 +283,10 @@ public class ProofOfConceptTests
         {
             // Arrange
             var builder = new PipelineBuilder<object?> { Components = new List<IBuilder<IPipelineComponent<object?>>>() };
+            var validationResults = new List<ValidationResult>();
 
             // Act
-            var validationResults = builder.Validate(new(builder));
+            _ = builder.TryValidate(validationResults);
 
             // Assert
             validationResults.Should().BeEmpty();
@@ -294,9 +297,10 @@ public class ProofOfConceptTests
         {
             // Arrange
             var builder = new PipelineBuilder<object?> { Components = new List<IBuilder<IPipelineComponent<object?>>>(new[] { new MyContextlessComponentBuilder() }) };
+            var validationResults = new List<ValidationResult>();
 
             // Act
-            var validationResults = builder.Validate(new(builder));
+            _ = builder.TryValidate(validationResults);
 
             // Assert
             validationResults.Should().BeEmpty();
@@ -307,9 +311,10 @@ public class ProofOfConceptTests
         {
             // Arrange
             var builder = new PipelineBuilder<object?> { Components = new List<IBuilder<IPipelineComponent<object?>>>(new[] { new MyContextlessValidatableComponentBuilder().WithProcessCallback(null!) }) };
+            var validationResults = new List<ValidationResult>();
 
             // Act
-            var validationResults = builder.Validate(new(builder));
+            _ = builder.TryValidate(validationResults);
 
             // Assert
             validationResults.Should().ContainSingle();

--- a/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
+++ b/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
@@ -2,7 +2,13 @@
 
 public class ProofOfConceptTests
 {
-    public class Pipeline_With_Context
+    protected IEnumerable<IPipelineComponent<TModel>> GetComponents<TModel>(IPipeline<TModel> instance)
+        => (instance.GetType().GetProperty(nameof(IPipelineBuilder<object>.Components))!.GetValue(instance) as IEnumerable<IPipelineComponent<TModel>>)!;
+
+    protected IEnumerable<IPipelineComponent<TModel, TContext>> GetComponents<TModel, TContext>(IPipeline<TModel, TContext> instance)
+        => (instance.GetType().GetProperty(nameof(IPipelineBuilder<object>.Components))!.GetValue(instance) as IEnumerable<IPipelineComponent<TModel, TContext>>)!;
+
+    public class Pipeline_With_Context : ProofOfConceptTests
     {
         [Fact]
         public void Can_Create_Pipeline()
@@ -16,8 +22,8 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().ContainSingle();
-            pipeline.Components.Single().Should().BeOfType<MyComponentWithContext>();
+            GetComponents(pipeline).Should().ContainSingle();
+            GetComponents(pipeline).Single().Should().BeOfType<MyComponentWithContext>();
         }
 
         [Fact]
@@ -32,8 +38,8 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().HaveCount(2);
-            pipeline.Components.Should().AllBeOfType<MyComponentWithContext>();
+            GetComponents(pipeline).Should().HaveCount(2);
+            GetComponents(pipeline).Should().AllBeOfType<MyComponentWithContext>();
         }
 
         [Fact]
@@ -48,8 +54,8 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().HaveCount(2);
-            pipeline.Components.Should().AllBeOfType<MyComponentWithContext>();
+            GetComponents(pipeline).Should().HaveCount(2);
+            GetComponents(pipeline).Should().AllBeOfType<MyComponentWithContext>();
         }
 
         [Fact]
@@ -65,8 +71,8 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().ContainSingle();
-            pipeline.Components.Single().Should().BeOfType<MyReplacedComponentWithContext>();
+            GetComponents(pipeline).Should().ContainSingle();
+            GetComponents(pipeline).Single().Should().BeOfType<MyReplacedComponentWithContext>();
         }
 
         [Fact]
@@ -82,7 +88,7 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().BeEmpty();
+            GetComponents(pipeline).Should().BeEmpty();
         }
 
         [Fact]
@@ -181,7 +187,7 @@ public class ProofOfConceptTests
         }
     }
 
-    public class Pipeline_Without_Context
+    public class Pipeline_Without_Context : ProofOfConceptTests
     {
         [Fact]
         public void Can_Create_Pipeline()
@@ -195,8 +201,8 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().ContainSingle();
-            pipeline.Components.Single().Should().BeOfType<MyContextlessComponent>();
+            GetComponents(pipeline).Should().ContainSingle();
+            GetComponents(pipeline).Single().Should().BeOfType<MyContextlessComponent>();
         }
 
         [Fact]
@@ -211,8 +217,8 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().HaveCount(2);
-            pipeline.Components.Should().AllBeOfType<MyContextlessComponent>();
+            GetComponents(pipeline).Should().HaveCount(2);
+            GetComponents(pipeline).Should().AllBeOfType<MyContextlessComponent>();
         }
 
         [Fact]
@@ -227,8 +233,8 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().HaveCount(2);
-            pipeline.Components.Should().AllBeOfType<MyContextlessComponent>();
+            GetComponents(pipeline).Should().HaveCount(2);
+            GetComponents(pipeline).Should().AllBeOfType<MyContextlessComponent>();
         }
 
         [Fact]
@@ -244,8 +250,8 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().ContainSingle();
-            pipeline.Components.Single().Should().BeOfType<MyReplacedContextlessComponent>();
+            GetComponents(pipeline).Should().ContainSingle();
+            GetComponents(pipeline).Single().Should().BeOfType<MyReplacedContextlessComponent>();
         }
 
         [Fact]
@@ -261,7 +267,7 @@ public class ProofOfConceptTests
                 .Build();
 
             // Assert
-            pipeline.Components.Should().BeEmpty();
+            GetComponents(pipeline).Should().BeEmpty();
         }
 
         [Fact]

--- a/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
+++ b/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
@@ -400,6 +400,40 @@ public class ProofOfConceptTests
         }
     }
 
+    public class PipelineComponent_With_Context()
+    {
+        [Fact]
+        public async Task Can_Call_Process_Without_CancellationToken()
+        {
+            // Arrange
+            var sut = new MyReplacedContextlessComponent();
+            var context = new PipelineContext<object?>(1);
+
+            // Act
+            var result = await sut.Process(context);
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.NotImplemented);
+        }
+    }
+
+    public class PipelineComponent_Without_Context()
+    {
+        [Fact]
+        public async Task Can_Call_Process_Without_CancellationToken()
+        {
+            // Arrange
+            var sut = new MyReplacedContextlessComponent();
+            var context = new PipelineContext<object?, object?>(1, 2);
+
+            // Act
+            var result = await sut.Process(context);
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.NotImplemented);
+        }
+    }
+
     private sealed class MyContextlessComponent : IPipelineComponent<object?>
     {
         public Func<PipelineContext<object?>, Result<object?>> ProcessCallback { get; }

--- a/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
+++ b/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
@@ -134,7 +134,7 @@ public class ProofOfConceptTests
         }
 
         [Fact]
-        public void Can_Process_Pipeline_With_Feature()
+        public async Task Can_Process_Pipeline_With_Feature()
         {
             // Arrange
             PipelineContext<object?, object?>? context = null;
@@ -144,7 +144,7 @@ public class ProofOfConceptTests
                 .Build();
 
             // Act
-            var result = sut.Process(model: 1, context: 2);
+            var result = await sut.Process(model: 1, context: 2);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -154,7 +154,7 @@ public class ProofOfConceptTests
         }
 
         [Fact]
-        public void Can_Abort_Pipeline_With_Feature_Using_Non_Success_Status()
+        public async Task Can_Abort_Pipeline_With_Feature_Using_Non_Success_Status()
         {
             // Arrange
             Func<PipelineContext<object?, object?>, Result<object?>> processCallback = new(_ => Result.Error<object?>("Kaboom"));
@@ -163,7 +163,7 @@ public class ProofOfConceptTests
                 .Build();
 
             // Act
-            var result = sut.Process(model: 1, context: 2);
+            var result = await sut.Process(model: 1, context: 2);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
@@ -328,7 +328,7 @@ public class ProofOfConceptTests
         }
 
         [Fact]
-        public void Can_Process_Pipeline_With_Feature()
+        public async Task Can_Process_Pipeline_With_Feature()
         {
             // Arrange
             PipelineContext<object?>? context = null;
@@ -338,7 +338,7 @@ public class ProofOfConceptTests
                 .Build();
 
             // Act
-            var result = sut.Process(model: 1);
+            var result = await sut.Process(model: 1);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -347,7 +347,7 @@ public class ProofOfConceptTests
         }
 
         [Fact]
-        public void Can_Abort_Pipeline_With_Feature_Using_Non_Success_Status()
+        public async Task Can_Abort_Pipeline_With_Feature_Using_Non_Success_Status()
         {
             // Arrange
             Func<PipelineContext<object?>, Result<object?>> processCallback = new(_ => Result.Error<object?>("Kaboom"));
@@ -356,7 +356,7 @@ public class ProofOfConceptTests
                 .Build();
 
             // Act
-            var result = sut.Process(model: 1);
+            var result = await sut.Process(model: 1);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
@@ -410,8 +410,8 @@ public class ProofOfConceptTests
         public MyContextlessComponent(Func<PipelineContext<object?>, Result<object?>> processCallback)
             => ProcessCallback = processCallback;
 
-        public Result<object?> Process(PipelineContext<object?> context)
-            => ProcessCallback.Invoke(context);
+        public Task<Result<object?>> Process(PipelineContext<object?> context, CancellationToken token)
+            => Task.FromResult(ProcessCallback.Invoke(context));
     }
 
     private sealed class MyContextlessComponentBuilder : IPipelineComponentBuilder<object?>
@@ -445,9 +445,9 @@ public class ProofOfConceptTests
 
     private sealed class MyReplacedContextlessComponent : IPipelineComponent<object?>
     {
-        public Result<object?> Process(PipelineContext<object?> context)
+        public Task<Result<object?>> Process(PipelineContext<object?> context, CancellationToken token)
         {
-            return Result.NotImplemented<object?>();
+            return Task.FromResult(Result.NotImplemented<object?>());
         }
     }
 
@@ -467,8 +467,8 @@ public class ProofOfConceptTests
         public MyComponentWithContext(Func<PipelineContext<object?, object?>, Result<object?>> processCallback)
             => ProcessCallback = processCallback;
 
-        public Result<object?> Process(PipelineContext<object?, object?> context)
-            => ProcessCallback.Invoke(context);
+        public Task<Result<object?>> Process(PipelineContext<object?, object?> context, CancellationToken token)
+            => Task.FromResult(ProcessCallback.Invoke(context));
     }
 
     private sealed class MyComponentWithContextBuilder : IPipelineComponentBuilder<object?, object?>
@@ -487,9 +487,9 @@ public class ProofOfConceptTests
 
     private sealed class MyReplacedComponentWithContext : IPipelineComponent<object?, object?>
     {
-        public Result<object?> Process(PipelineContext<object?, object?> context)
+        public Task<Result<object?>> Process(PipelineContext<object?, object?> context, CancellationToken token)
         {
-            return Result.NotImplemented<object?>();
+            return Task.FromResult(Result.NotImplemented<object?>());
         }
     }
 

--- a/src/CrossCutting.ProcessingPipeline/AbstractPipelineBase.cs
+++ b/src/CrossCutting.ProcessingPipeline/AbstractPipelineBase.cs
@@ -2,7 +2,7 @@
 
 public abstract class AbstractPipelineBase<T>
 {
-    [Required]
+    [Required][ValidateObject]
     public IReadOnlyCollection<T> Components { get; }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
+++ b/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.ProcessingPipeline</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>5.0.1</Version>
-    <PackageVersion>5.0.1</PackageVersion>
+    <Version>6.0.0</Version>
+    <PackageVersion>6.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.ProcessingPipeline/GlobalUsings.cs
+++ b/src/CrossCutting.ProcessingPipeline/GlobalUsings.cs
@@ -3,6 +3,8 @@ global using System.Collections.Generic;
 global using System.Collections.ObjectModel;
 global using System.ComponentModel.DataAnnotations;
 global using System.Linq;
+global using System.Threading;
+global using System.Threading.Tasks;
 global using CrossCutting.Common;
 global using CrossCutting.Common.DataAnnotations;
 global using CrossCutting.Common.Results;

--- a/src/CrossCutting.ProcessingPipeline/GlobalUsings.cs
+++ b/src/CrossCutting.ProcessingPipeline/GlobalUsings.cs
@@ -4,4 +4,5 @@ global using System.Collections.ObjectModel;
 global using System.ComponentModel.DataAnnotations;
 global using System.Linq;
 global using CrossCutting.Common;
+global using CrossCutting.Common.DataAnnotations;
 global using CrossCutting.Common.Results;

--- a/src/CrossCutting.ProcessingPipeline/IPipeline.cs
+++ b/src/CrossCutting.ProcessingPipeline/IPipeline.cs
@@ -2,14 +2,10 @@
 
 public interface IPipeline<TModel>
 {
-    IReadOnlyCollection<IPipelineComponent<TModel>> Components { get; }
-    
     Result<TModel> Process(TModel model);
 }
 
 public interface IPipeline<TModel, TContext>
 {
-    IReadOnlyCollection<IPipelineComponent<TModel, TContext>> Components { get; }
-
     Result<TModel> Process(TModel model, TContext context);
 }

--- a/src/CrossCutting.ProcessingPipeline/IPipeline.cs
+++ b/src/CrossCutting.ProcessingPipeline/IPipeline.cs
@@ -2,10 +2,10 @@
 
 public interface IPipeline<TModel>
 {
-    Result<TModel> Process(TModel model);
+    Task<Result<TModel>> Process(TModel model, CancellationToken token);
 }
 
 public interface IPipeline<TModel, TContext>
 {
-    Result<TModel> Process(TModel model, TContext context);
+    Task<Result<TModel>> Process(TModel model, TContext context, CancellationToken token);
 }

--- a/src/CrossCutting.ProcessingPipeline/IPipelineBuilder.cs
+++ b/src/CrossCutting.ProcessingPipeline/IPipelineBuilder.cs
@@ -1,11 +1,11 @@
 ﻿namespace CrossCutting.ProcessingPipeline;
 
-public interface IPipelineBuilder<TModel> : IValidatableObject
+public interface IPipelineBuilder<TModel>
 {
     public IPipeline<TModel> Build();
 }
 
-public interface IPipelineBuilder<TModel, TContext> : IValidatableObject
+public interface IPipelineBuilder<TModel, TContext>
 {
     public IPipeline<TModel, TContext> Build();
 }

--- a/src/CrossCutting.ProcessingPipeline/IPipelineBuilder.cs
+++ b/src/CrossCutting.ProcessingPipeline/IPipelineBuilder.cs
@@ -2,10 +2,14 @@
 
 public interface IPipelineBuilder<TModel>
 {
+    IList<IBuilder<IPipelineComponent<TModel>>> Components { get; }
+
     public IPipeline<TModel> Build();
 }
 
 public interface IPipelineBuilder<TModel, TContext>
 {
+    IList<IBuilder<IPipelineComponent<TModel, TContext>>> Components { get; }
+
     public IPipeline<TModel, TContext> Build();
 }

--- a/src/CrossCutting.ProcessingPipeline/IPipelineComponent..cs
+++ b/src/CrossCutting.ProcessingPipeline/IPipelineComponent..cs
@@ -2,10 +2,10 @@
 
 public interface IPipelineComponent<TModel>
 {
-    Result<TModel> Process(PipelineContext<TModel> context);
+    Task<Result<TModel>> Process(PipelineContext<TModel> context, CancellationToken token);
 }
 
 public interface IPipelineComponent<TModel, TContext>
 {
-    Result<TModel> Process(PipelineContext<TModel, TContext> context);
+    Task<Result<TModel>> Process(PipelineContext<TModel, TContext> context, CancellationToken token);
 }

--- a/src/CrossCutting.ProcessingPipeline/PipelineBuilder.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineBuilder.cs
@@ -9,14 +9,6 @@ public class PipelineBuilder<TModel> : PipelineBuilderBase<IPipelineComponent<TM
     public IPipeline<TModel> Build()
         => new Pipeline<TModel>(Initialize, Components.Select(x => x.Build()));
 
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        var validationResults = new List<ValidationResult>();
-        _ = Validator.TryValidateObject(this, new ValidationContext(this, null, null), validationResults, true);
-        return validationResults;
-    }
-
-
     protected virtual void Initialize(TModel model, PipelineContext<TModel> pipelineContext)
     {
     }
@@ -30,9 +22,6 @@ public class PipelineBuilder<TModel, TContext> : PipelineBuilderBase<IPipelineCo
 
     public IPipeline<TModel, TContext> Build()
         => new Pipeline<TModel, TContext>(Initialize, Components.Select(x => x.Build()));
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        => Validate(new PipelineBase<TModel, TContext>(Components?.Select(x => x.Build())));
 
     protected virtual void Initialize(TModel model, PipelineContext<TModel, TContext> pipelineContext)
     {

--- a/src/CrossCutting.ProcessingPipeline/PipelineBuilder.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineBuilder.cs
@@ -10,7 +10,11 @@ public class PipelineBuilder<TModel> : PipelineBuilderBase<IPipelineComponent<TM
         => new Pipeline<TModel>(Initialize, Components.Select(x => x.Build()));
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        => Validate(new PipelineBase<TModel>(Components?.Select(x => x.Build())));
+    {
+        var validationResults = new List<ValidationResult>();
+        _ = Validator.TryValidateObject(this, new ValidationContext(this, null, null), validationResults, true);
+        return validationResults;
+    }
 
 
     protected virtual void Initialize(TModel model, PipelineContext<TModel> pipelineContext)

--- a/src/CrossCutting.ProcessingPipeline/PipelineBuilderBase.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineBuilderBase.cs
@@ -4,6 +4,7 @@ public abstract class PipelineBuilderBase<T, TResult>
     where TResult : PipelineBuilderBase<T, TResult>
 {
 #pragma warning disable CA2227 // Collection properties should be read only
+    [ValidateObject]
     public IList<IBuilder<T>> Components
 #pragma warning restore CA2227 // Collection properties should be read only
     {

--- a/src/CrossCutting.ProcessingPipeline/PipelineBuilderBase.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineBuilderBase.cs
@@ -4,7 +4,7 @@ public abstract class PipelineBuilderBase<T, TResult>
     where TResult : PipelineBuilderBase<T, TResult>
 {
 #pragma warning disable CA2227 // Collection properties should be read only
-    [ValidateObject]
+    [Required][ValidateObject]
     public IList<IBuilder<T>> Components
 #pragma warning restore CA2227 // Collection properties should be read only
     {
@@ -42,13 +42,6 @@ public abstract class PipelineBuilderBase<T, TResult>
         }
 
         return (TResult)this;
-    }
-
-    protected IEnumerable<ValidationResult> Validate(object instance)
-    {
-        var results = new List<ValidationResult>();
-        Validator.TryValidateObject(instance.IsNotNull(nameof(instance)), new ValidationContext(instance, null, null), results, true);
-        return results;
     }
 
     protected PipelineBuilderBase()

--- a/src/CrossCutting.ProcessingPipeline/PipelineComponentExtensions.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineComponentExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace CrossCutting.ProcessingPipeline;
+
+public static class PipelineComponentExtensions
+{
+    public static Task<Result<TModel>> Process<TModel>(this IPipelineComponent<TModel> instance, PipelineContext<TModel> context)
+        => instance.Process(context, CancellationToken.None);
+
+    public static Task<Result<TModel>> Process<TModel, TContext>(this IPipelineComponent<TModel, TContext> instance, PipelineContext<TModel, TContext> context)
+        => instance.Process(context, CancellationToken.None);
+}

--- a/src/CrossCutting.ProcessingPipeline/PipelineExtensions.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace CrossCutting.ProcessingPipeline;
+
+public static class PipelineExtensions
+{
+    public static Task<Result<TModel>> Process<TModel>(this IPipeline<TModel> pipeline, TModel model)
+        => pipeline.Process(model, new CancellationToken());
+
+    public static Task<Result<TModel>> Process<TModel, TContext>(this IPipeline<TModel, TContext> pipeline, TModel model, TContext context)
+        => pipeline.Process(model, context, new CancellationToken());
+}

--- a/src/CrossCutting.ProcessingPipeline/PipelineExtensions.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineExtensions.cs
@@ -3,8 +3,8 @@
 public static class PipelineExtensions
 {
     public static Task<Result<TModel>> Process<TModel>(this IPipeline<TModel> pipeline, TModel model)
-        => pipeline.Process(model, new CancellationToken());
+        => pipeline.Process(model, CancellationToken.None);
 
     public static Task<Result<TModel>> Process<TModel, TContext>(this IPipeline<TModel, TContext> pipeline, TModel model, TContext context)
-        => pipeline.Process(model, context, new CancellationToken());
+        => pipeline.Process(model, context, CancellationToken.None);
 }

--- a/src/CrossCutting.Utilities.Aggregators/CrossCutting.Utilities.Aggregators.csproj
+++ b/src/CrossCutting.Utilities.Aggregators/CrossCutting.Utilities.Aggregators.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Aggregators</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.8.0</Version>
-    <PackageVersion>3.8.0</PackageVersion>
+    <Version>3.9.0</Version>
+    <PackageVersion>3.9.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
@@ -12,12 +12,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.7.0">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Utilities.ObjectDumper/CrossCutting.Utilities.ObjectDumper.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper/CrossCutting.Utilities.ObjectDumper.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Utilities.ObjectDumper</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.8.0</Version>
-    <PackageVersion>3.8.0</PackageVersion>
+    <Version>3.9.0</Version>
+    <PackageVersion>3.9.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Utilities.Operators/CrossCutting.Utilities.Operators.csproj
+++ b/src/CrossCutting.Utilities.Operators/CrossCutting.Utilities.Operators.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Operators</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.8.0</Version>
-    <PackageVersion>3.8.0</PackageVersion>
+    <Version>3.9.0</Version>
+    <PackageVersion>3.9.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
+++ b/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.7.0">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionStringParserTests.cs
@@ -751,10 +751,10 @@ public sealed class ExpressionStringParserTests : IDisposable
     {
         public int Order => 10;
 
-        public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result<FormattableStringParserResult> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
-                ? Result.Success(ReplacedValue)
-                : Result.Error<string>($"Unsupported placeholder name: {value}");
+                ? Result.Success(new FormattableStringParserResult(ReplacedValue))
+                : Result.Error<FormattableStringParserResult>($"Unsupported placeholder name: {value}");
     }
 
     private sealed class MyFunctionResultParser : IFunctionResultParser

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -245,6 +245,28 @@ public sealed class FormattableStringParserTests : IDisposable
         result.Should().BeOfType<FormattableStringParser>();
     }
 
+    [Fact]
+    public void FromString_Creates_New_Instance_From_String_Correclty()
+    {
+        // Act
+        var instance = FormattableStringParserResult.FromString("hello world");
+
+        // Assert
+        instance.Format.Should().Be("{0}");
+        instance.ToString().Should().Be("hello world");
+    }
+
+    [Fact]
+    public void FromString_Creates_New_Instance_From_String_With_Accolades_Correclty()
+    {
+        // Act
+        var instance = FormattableStringParserResult.FromString("hello {world}");
+
+        // Assert
+        instance.Format.Should().Be("{0}");
+        instance.ToString().Should().Be("hello {world}");
+    }
+
     public void Dispose()
     {
         _scope?.Dispose();
@@ -270,10 +292,10 @@ public sealed class FormattableStringParserTests : IDisposable
         {
             return value switch
             {
-                "Name" => Result.Success(ReplacedValue.ToFormattableStringParserResult()),
-                "Context" => Result.Success(context.ToStringWithDefault().ToFormattableStringParserResult()),
+                "Name" => Result.Success<FormattableStringParserResult>(ReplacedValue),
+                "Context" => Result.Success<FormattableStringParserResult>(context.ToStringWithDefault()),
                 "Unsupported placeholder" => Result.Error<FormattableStringParserResult>($"Unsupported placeholder name: {value}"),
-                "ReplaceWithPlaceholder" => Result.Success("{Name}".ToFormattableStringParserResult()),
+                "ReplaceWithPlaceholder" => Result.Success<FormattableStringParserResult>("{Name}"),
                 _ => Result.Continue<FormattableStringParserResult>()
             };
         }

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -188,11 +188,13 @@ public sealed class FormattableStringParserTests : IDisposable
         var preparsedResult = sut.Parse("Hello {Name}, you are called {{Name}}", CultureInfo.InvariantCulture);
 
         // Act
-        var result = sut.Parse(preparsedResult.GetValueOrThrow().ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
+        var result = sut.Parse(preparsedResult.GetValueOrThrow(), CultureInfo.InvariantCulture);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().Be($"Hello {ReplacedValue}, you are called {ReplacedValue}");
+        result.Value!.ToString().Should().Be($"Hello {ReplacedValue}, you are called {ReplacedValue}");
+        result.Value.ArgumentCount.Should().Be(1);
+        result.Value.GetArgument(0).Should().BeEquivalentTo(ReplacedValue);
     }
 
     [Fact]

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -185,10 +185,10 @@ public sealed class FormattableStringParserTests : IDisposable
     {
         // Arrange
         var sut = CreateSut();
-        var preparsedResult = sut.Parse("Hello {Name}, you are called {{Name}}", CultureInfo.InvariantCulture);
+        var preparsedResult = sut.Parse("Hello {Name}, you are called {{Name}}", CultureInfo.InvariantCulture).GetValueOrThrow();
 
         // Act
-        var result = sut.Parse(preparsedResult.GetValueOrThrow(), CultureInfo.InvariantCulture);
+        var result = sut.Parse(preparsedResult, CultureInfo.InvariantCulture);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -212,6 +212,19 @@ public sealed class FormattableStringParserTests : IDisposable
     }
 
     [Fact]
+    public void Can_Implicitly_Convert_Null_ParseStringResult_To_String()
+    {
+        // Arrange
+        var parsedResult = default(FormattableStringParserResult);
+
+        // Act
+        string result = parsedResult!;
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public void Create_Throws_On_Null_Processors()
     {
         // Act & Assert

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -267,6 +267,32 @@ public sealed class FormattableStringParserTests : IDisposable
         instance.ToString().Should().Be("hello {world}");
     }
 
+    [Fact]
+    public void ToString_Override_Returns_Correct_Result()
+    {
+        // Arrange
+        FormattableStringParserResult result = "Hello world!";
+
+        // Act
+        var stringResult = result.ToString();
+
+        // Assert
+        stringResult.Should().Be("Hello world!");
+    }
+
+    [Fact]
+    public void Implicit_Operator_Returns_Correct_Result()
+    {
+        // Arrange
+        FormattableStringParserResult result = "Hello world!";
+
+        // Act
+        string stringResult = result;
+
+        // Assert
+        stringResult.Should().Be("Hello world!");
+    }
+
     public void Dispose()
     {
         _scope?.Dispose();

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -1,6 +1,4 @@
-﻿using CrossCutting.Common.Extensions;
-
-namespace CrossCutting.Utilities.Parsers.Tests;
+﻿namespace CrossCutting.Utilities.Parsers.Tests;
 
 public sealed class FormattableStringParserTests : IDisposable
 {
@@ -97,7 +95,7 @@ public sealed class FormattableStringParserTests : IDisposable
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().Be(expectedValue);
+        result.Value!.ToString().Should().Be(expectedValue);
     }
 
     [Fact]
@@ -135,7 +133,7 @@ public sealed class FormattableStringParserTests : IDisposable
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().Be("Hello function result!");
+        result.Value!.ToString().Should().Be("Hello function result!");
     }
 
     [Fact]
@@ -149,7 +147,7 @@ public sealed class FormattableStringParserTests : IDisposable
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().Be("I can add 1 to 2, this results in 2");
+        result.Value!.ToString().Should().Be("I can add 1 to 2, this results in 2");
     }
 
     [Fact]
@@ -165,7 +163,7 @@ public sealed class FormattableStringParserTests : IDisposable
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
-        result.Value.Should().Be($"Hello {ReplacedValue}!");
+        result.Value!.ToString().Should().Be($"Hello {ReplacedValue}!");
     }
 
     [Fact]
@@ -195,6 +193,20 @@ public sealed class FormattableStringParserTests : IDisposable
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().Be($"Hello {ReplacedValue}, you are called {ReplacedValue}");
+    }
+
+    [Fact]
+    public void Can_Implicitly_Convert_ParseStringResult_To_String()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var parsedResult = sut.Parse("Hello {Name}!", CultureInfo.InvariantCulture);
+
+        // Act
+        string result = parsedResult.GetValueOrThrow();
+
+        // Assert
+        result.Should().Be("Hello replaced name!");
     }
 
     [Fact]

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -1,4 +1,6 @@
-﻿namespace CrossCutting.Utilities.Parsers.Tests;
+﻿using CrossCutting.Common.Extensions;
+
+namespace CrossCutting.Utilities.Parsers.Tests;
 
 public sealed class FormattableStringParserTests : IDisposable
 {
@@ -159,7 +161,7 @@ public sealed class FormattableStringParserTests : IDisposable
 
         // Act
         var result = sut.Parse(Input, CultureInfo.InvariantCulture);
-        result = sut.Parse(result.GetValueOrThrow(), CultureInfo.InvariantCulture); // have to parse the result, because it contains a new placeholder...
+        result = sut.Parse(result.GetValueOrThrow().ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture); // have to parse the result, because it contains a new placeholder...
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -188,7 +190,7 @@ public sealed class FormattableStringParserTests : IDisposable
         var preparsedResult = sut.Parse("Hello {Name}, you are called {{Name}}", CultureInfo.InvariantCulture);
 
         // Act
-        var result = sut.Parse(preparsedResult.GetValueOrThrow(), CultureInfo.InvariantCulture);
+        var result = sut.Parse(preparsedResult.GetValueOrThrow().ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -237,15 +239,15 @@ public sealed class FormattableStringParserTests : IDisposable
     {
         public int Order => 10;
 
-        public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result<FormattableStringParserResult> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
         {
             return value switch
             {
-                "Name" => Result.Success(ReplacedValue),
-                "Context" => Result.Success(context?.ToString() ?? string.Empty),
-                "Unsupported placeholder" => Result.Error<string>($"Unsupported placeholder name: {value}"),
-                "ReplaceWithPlaceholder" => Result.Success("{Name}"),
-                _ => Result.Continue<string>()
+                "Name" => Result.Success(ReplacedValue.ToFormattableStringParserResult()),
+                "Context" => Result.Success(context.ToStringWithDefault().ToFormattableStringParserResult()),
+                "Unsupported placeholder" => Result.Error<FormattableStringParserResult>($"Unsupported placeholder name: {value}"),
+                "ReplaceWithPlaceholder" => Result.Success("{Name}".ToFormattableStringParserResult()),
+                _ => Result.Continue<FormattableStringParserResult>()
             };
         }
     }

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
@@ -417,9 +417,9 @@ public sealed class FunctionParserTests : IDisposable
     {
         public int Order => 10;
 
-        public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result<FormattableStringParserResult> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
-                ? Result.Success(ReplacedValue)
-                : Result.Error<string>($"Unsupported placeholder name: {value}");
+                ? Result.Success(ReplacedValue.ToFormattableStringParserResult())
+                : Result.Error<FormattableStringParserResult>($"Unsupported placeholder name: {value}");
     }
 }

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
@@ -419,7 +419,7 @@ public sealed class FunctionParserTests : IDisposable
 
         public Result<FormattableStringParserResult> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
-                ? Result.Success(ReplacedValue.ToFormattableStringParserResult())
+                ? Result.Success<FormattableStringParserResult>(ReplacedValue)
                 : Result.Error<FormattableStringParserResult>($"Unsupported placeholder name: {value}");
     }
 }

--- a/src/CrossCutting.Utilities.Parsers.Tests/GlobalUsings.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/GlobalUsings.cs
@@ -2,6 +2,7 @@
 global using System.Collections.Generic;
 global using System.Globalization;
 global using System.Linq;
+global using CrossCutting.Common.Extensions;
 global using CrossCutting.Common.Results;
 global using CrossCutting.Utilities.Aggregators;
 global using CrossCutting.Utilities.Parsers.Builders;

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IFormattableStringParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IFormattableStringParser.cs
@@ -2,5 +2,5 @@
 
 public interface IFormattableStringParser
 {
-    Result<string> Parse(string input, IFormatProvider formatProvider, object? context);
+    Result<FormattableStringParserResult> Parse(string input, IFormatProvider formatProvider, object? context);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IFormattableStringStateProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IFormattableStringStateProcessor.cs
@@ -2,5 +2,5 @@
 
 public interface IFormattableStringStateProcessor
 {
-    Result<string> Process(FormattableStringParserState state);
+    Result<FormattableStringParserResult> Process(FormattableStringParserState state);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IPlaceholderProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IPlaceholderProcessor.cs
@@ -3,5 +3,5 @@
 public interface IPlaceholderProcessor
 {
     int Order { get; }
-    Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser);
+    Result<FormattableStringParserResult> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
+++ b/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Parsers</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>4.0.0</Version>
-    <PackageVersion>4.0.0</PackageVersion>
+    <Version>5.0.0</Version>
+    <PackageVersion>5.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/FormattableStringExpressionProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringParserProcessors/FormattableStringExpressionProcessor.cs
@@ -12,7 +12,7 @@ public class FormattableStringExpressionProcessor : IExpressionStringParserProce
         {
             // =@"string value" -> literal, no functions but formattable strings possible
             return state.FormattableStringParser is not null
-                ? Result.FromExistingResult<object?>(state.FormattableStringParser.Parse(state.Input.Substring(3, state.Input.Length - 4), state.FormatProvider, state.Context))
+                ? Result.FromExistingResult<FormattableStringParserResult, object?>(state.FormattableStringParser.Parse(state.Input.Substring(3, state.Input.Length - 4), state.FormatProvider, state.Context), value => value.ToString(state.FormatProvider))
                 : Result.Success<object?>(state.Input.Substring(3, state.Input.Length - 4));
         }
         else if (state.Input.StartsWith("=\"") && state.Input.EndsWith("\""))

--- a/src/CrossCutting.Utilities.Parsers/Extensions/FormattableStringParserExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/FormattableStringParserExtensions.cs
@@ -2,6 +2,6 @@
 
 public static class FormattableStringParserExtensions
 {
-    public static Result<string> Parse(this IFormattableStringParser instance, string input, IFormatProvider formatProvider)
+    public static Result<FormattableStringParserResult> Parse(this IFormattableStringParser instance, string input, IFormatProvider formatProvider)
         => instance.Parse(input, formatProvider, null);
 }

--- a/src/CrossCutting.Utilities.Parsers/Extensions/StringExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/StringExtensions.cs
@@ -1,7 +1,0 @@
-﻿namespace CrossCutting.Utilities.Parsers.Extensions;
-
-public static class StringExtensions
-{
-    public static FormattableStringParserResult ToFormattableStringParserResult(this string instance)
-        => new FormattableStringParserResult(instance);
-}

--- a/src/CrossCutting.Utilities.Parsers/Extensions/StringExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/StringExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace CrossCutting.Utilities.Parsers.Extensions;
+
+public static class StringExtensions
+{
+    public static FormattableStringParserResult ToFormattableStringParserResult(this string instance)
+        => new FormattableStringParserResult(instance);
+}

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParser.cs
@@ -27,7 +27,7 @@ public class FormattableStringParser : IFormattableStringParser
             ]);
     }
 
-    public Result<string> Parse(string input, IFormatProvider formatProvider, object? context)
+    public Result<FormattableStringParserResult> Parse(string input, IFormatProvider formatProvider, object? context)
     {
         input = input.IsNotNull(nameof(input));
         formatProvider = formatProvider.IsNotNull(nameof(formatProvider));
@@ -54,9 +54,9 @@ public class FormattableStringParser : IFormattableStringParser
 
         if (state.InPlaceholder)
         {
-            return Result.Invalid<string>("Missing close sign '}'. To use the '{' character, you have to escape it with an additional '{' character");
+            return Result.Invalid<FormattableStringParserResult>("Missing close sign '}'. To use the '{' character, you have to escape it with an additional '{' character");
         }
 
-        return Result.Success(state.ResultBuilder.ToString());
+        return Result.Success(new FormattableStringParserResult(state.ResultFormat, state.ResultArguments.ToArray()));
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserResult.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserResult.cs
@@ -1,0 +1,33 @@
+﻿namespace CrossCutting.Utilities.Parsers;
+
+public class FormattableStringParserResult : FormattableString
+{
+    private readonly object[] _arguments;
+
+    public FormattableStringParserResult(object? value) : this("{0}", [value!])
+    {
+    }
+
+    public FormattableStringParserResult(string format, object[] arguments)
+    {
+        Format = format.IsNotNull(nameof(format));
+        _arguments = arguments.IsNotNull(nameof(arguments));
+    }
+
+    public override int ArgumentCount
+        => _arguments.Length;
+
+    public override string Format { get; }
+
+    public override object GetArgument(int index)
+        => _arguments[index];
+
+    public override object[] GetArguments()
+        => _arguments;
+
+    public override string ToString(IFormatProvider formatProvider)
+        => string.Format(formatProvider, Format, _arguments);
+
+    //TODO: Review if we need this
+    //public static implicit operator string(FormattableStringParserResult r) => r?.ToString()!;
+}

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserResult.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserResult.cs
@@ -28,6 +28,9 @@ public class FormattableStringParserResult : FormattableString
     public override string ToString(IFormatProvider formatProvider)
         => string.Format(formatProvider, Format, _arguments);
 
+    public override string ToString()
+        => string.Format(Format, _arguments);
+
     public static FormattableStringParserResult FromString(string s) => new FormattableStringParserResult(s);
 
     public static implicit operator string(FormattableStringParserResult r) => r?.ToString()!;

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserResult.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserResult.cs
@@ -28,5 +28,9 @@ public class FormattableStringParserResult : FormattableString
     public override string ToString(IFormatProvider formatProvider)
         => string.Format(formatProvider, Format, _arguments);
 
+    public static FormattableStringParserResult FromString(string s) => new FormattableStringParserResult(s);
+
     public static implicit operator string(FormattableStringParserResult r) => r?.ToString()!;
+
+    public static implicit operator FormattableStringParserResult(string s) => FromString(s);
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserResult.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserResult.cs
@@ -28,6 +28,5 @@ public class FormattableStringParserResult : FormattableString
     public override string ToString(IFormatProvider formatProvider)
         => string.Format(formatProvider, Format, _arguments);
 
-    //TODO: Review if we need this
-    //public static implicit operator string(FormattableStringParserResult r) => r?.ToString()!;
+    public static implicit operator string(FormattableStringParserResult r) => r?.ToString()!;
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
@@ -12,7 +12,6 @@ public class FormattableStringParserState
     public bool InPlaceholder { get; private set; }
     public char Current { get; private set; }
     public int Index { get; private set; }
-    public bool IsEscaped { get; private set; }
     public string ResultFormat => ResultBuilder.ToString();
     public Collection<object> ResultArguments { get; } = new();
 
@@ -56,10 +55,6 @@ public class FormattableStringParserState
         Index = index;
         return this;
     }
-
-    public void Escape() => IsEscaped = true;
-
-    public void ResetEscape() => IsEscaped = false;
 
     public void StartPlaceholder() => InPlaceholder = true;
 

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
@@ -63,8 +63,17 @@ public class FormattableStringParserState
         value = value.IsNotNull(nameof(value));
 
         InPlaceholder = false;
-        ResultBuilder.Append(value.Format);
-        ResultArguments.AddRange(value.GetArguments());
+        var format = value.Format;
+        var previousCount = ResultArguments.Count;
+        for (int i = 0; i < value.GetArguments().Length; i++)
+        {
+            if (previousCount > 0)
+            {
+                format = format.Replace($"{{{i}}}", $"{{{i + previousCount}}}");
+            }
+            ResultArguments.Add(value.GetArgument(i));
+        }
+        ResultBuilder.Append(format);
         PlaceholderBuilder.Clear();
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParserState.cs
@@ -13,6 +13,8 @@ public class FormattableStringParserState
     public char Current { get; private set; }
     public int Index { get; private set; }
     public bool IsEscaped { get; private set; }
+    public string ResultFormat => ResultBuilder.ToString();
+    public Collection<object> ResultArguments { get; } = new();
 
     public FormattableStringParserState(string input, IFormatProvider formatProvider, object? context, IFormattableStringParser parser)
     {
@@ -48,7 +50,7 @@ public class FormattableStringParserState
         return Input[Index - 1] == sign;
     }
 
-    internal FormattableStringParserState Update(char current, int index)
+    public FormattableStringParserState Update(char current, int index)
     {
         Current = current;
         Index = index;
@@ -61,12 +63,13 @@ public class FormattableStringParserState
 
     public void StartPlaceholder() => InPlaceholder = true;
 
-    public void ClosePlaceholder(string value)
+    public void ClosePlaceholder(FormattableStringParserResult value)
     {
-        ArgumentGuard.IsNotNull(value, nameof(value));
+        value = value.IsNotNull(nameof(value));
 
         InPlaceholder = false;
-        ResultBuilder.Append(value);
+        ResultBuilder.Append(value.Format);
+        ResultArguments.AddRange(value.GetArguments());
         PlaceholderBuilder.Clear();
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/CloseSignProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/CloseSignProcessor.cs
@@ -9,13 +9,13 @@ public class CloseSignProcessor : IFormattableStringStateProcessor
         _processors = processors;
     }
 
-    public Result<string> Process(FormattableStringParserState state)
+    public Result<FormattableStringParserResult> Process(FormattableStringParserState state)
     {
         state = ArgumentGuard.IsNotNull(state, nameof(state));
 
         if (state.Current != FormattableStringParser.CloseSign)
         {
-            return Result.Continue<string>();
+            return Result.Continue<FormattableStringParserResult>();
         }
 
         if (state.NextPositionIsSign(FormattableStringParser.CloseSign)
@@ -26,19 +26,19 @@ public class CloseSignProcessor : IFormattableStringStateProcessor
                 state.Escape();
             }
 
-            return Result.Continue<string>();
+            return Result.Continue<FormattableStringParserResult>();
         }
 
         if (!state.InPlaceholder)
         {
-            return Result.Invalid<string>("Missing open sign '{'. To use the '}' character, you have to escape it with an additional '}' character");
+            return Result.Invalid<FormattableStringParserResult>("Missing open sign '{'. To use the '}' character, you have to escape it with an additional '}' character");
         }
 
         var placeholderResult = _processors
             .OrderBy(x => x.Order)
             .Select(x => x.Process(state.PlaceholderBuilder.ToString(), state.FormatProvider, state.Context, state.Parser))
             .FirstOrDefault(x => x.Status != ResultStatus.Continue)
-                ?? Result.Invalid<string>($"Unknown placeholder in value: {state.PlaceholderBuilder}");
+                ?? Result.Invalid<FormattableStringParserResult>($"Unknown placeholder in value: {state.PlaceholderBuilder}");
 
         if (!placeholderResult.IsSuccessful())
         {
@@ -47,6 +47,6 @@ public class CloseSignProcessor : IFormattableStringStateProcessor
 
         state.ClosePlaceholder(placeholderResult.Value!);
 
-        return Result.NoContent<string>();
+        return Result.NoContent<FormattableStringParserResult>();
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/CloseSignProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/CloseSignProcessor.cs
@@ -21,11 +21,6 @@ public class CloseSignProcessor : IFormattableStringStateProcessor
         if (state.NextPositionIsSign(FormattableStringParser.CloseSign)
             || state.PreviousPositionIsSign(FormattableStringParser.CloseSign))
         {
-            if (state.NextPositionIsSign(FormattableStringParser.CloseSign))
-            {
-                state.Escape();
-            }
-
             return Result.Continue<FormattableStringParserResult>();
         }
 

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/OpenSignProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/OpenSignProcessor.cs
@@ -14,11 +14,6 @@ public class OpenSignProcessor : IFormattableStringStateProcessor
         if (state.NextPositionIsSign(FormattableStringParser.OpenSign)
             || state.PreviousPositionIsSign(FormattableStringParser.OpenSign))
         {
-            if (state.NextPositionIsSign(FormattableStringParser.OpenSign))
-            {
-                state.Escape();
-            }
-
             return Result.Continue<FormattableStringParserResult>();
         }
 

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/OpenSignProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/OpenSignProcessor.cs
@@ -2,13 +2,13 @@
 
 public class OpenSignProcessor : IFormattableStringStateProcessor
 {
-    public Result<string> Process(FormattableStringParserState state)
+    public Result<FormattableStringParserResult> Process(FormattableStringParserState state)
     {
         state = ArgumentGuard.IsNotNull(state, nameof(state));
 
         if (state.Current != FormattableStringParser.OpenSign)
         {
-            return Result.Continue<string>();
+            return Result.Continue<FormattableStringParserResult>();
         }
 
         if (state.NextPositionIsSign(FormattableStringParser.OpenSign)
@@ -19,16 +19,16 @@ public class OpenSignProcessor : IFormattableStringStateProcessor
                 state.Escape();
             }
 
-            return Result.Continue<string>();
+            return Result.Continue<FormattableStringParserResult>();
         }
 
         if (state.InPlaceholder)
         {
-            return Result.Invalid<string>("Recursive placeholder detected, this is not supported");
+            return Result.Invalid<FormattableStringParserResult>("Recursive placeholder detected, this is not supported");
         }
 
         state.StartPlaceholder();
 
-        return Result.NoContent<string>();
+        return Result.NoContent<FormattableStringParserResult>();
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/PlaceholderProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/PlaceholderProcessor.cs
@@ -2,17 +2,17 @@
 
 public class PlaceholderProcessor : IFormattableStringStateProcessor
 {
-    public Result<string> Process(FormattableStringParserState state)
+    public Result<FormattableStringParserResult> Process(FormattableStringParserState state)
     {
         state = ArgumentGuard.IsNotNull(state, nameof(state));
 
         if (!state.InPlaceholder)
         {
-            return Result.Continue<string>();
+            return Result.Continue<FormattableStringParserResult>();
         }
 
         state.PlaceholderBuilder.Append(state.Current);
 
-        return Result.NoContent<string>();
+        return Result.NoContent<FormattableStringParserResult>();
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/ResultProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/ResultProcessor.cs
@@ -2,7 +2,7 @@
 
 public class ResultProcessor : IFormattableStringStateProcessor
 {
-    public Result<string> Process(FormattableStringParserState state)
+    public Result<FormattableStringParserResult> Process(FormattableStringParserState state)
     {
         state = ArgumentGuard.IsNotNull(state, nameof(state));
 
@@ -15,6 +15,6 @@ public class ResultProcessor : IFormattableStringStateProcessor
             state.ResultBuilder.Append(state.Current);
         }
 
-        return Result.NoContent<string>();
+        return Result.NoContent<FormattableStringParserResult>();
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/ResultProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringStateProcessors/ResultProcessor.cs
@@ -6,14 +6,7 @@ public class ResultProcessor : IFormattableStringStateProcessor
     {
         state = ArgumentGuard.IsNotNull(state, nameof(state));
 
-        if (state.IsEscaped)
-        {
-            state.ResetEscape();
-        }
-        else
-        {
-            state.ResultBuilder.Append(state.Current);
-        }
+        state.ResultBuilder.Append(state.Current);
 
         return Result.NoContent<FormattableStringParserResult>();
     }

--- a/src/CrossCutting.Utilities.Parsers/FunctionParserArgumentProcessors/FormattableStringFunctionParserArgumentProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParserArgumentProcessors/FormattableStringFunctionParserArgumentProcessor.cs
@@ -12,7 +12,7 @@ public class FormattableStringFunctionParserArgumentProcessor : IFunctionParserA
         {
             var result = formattableStringParser.Parse(stringArgument.Substring(1), formatProvider, context);
             return result.IsSuccessful()
-                ? Result.Success<FunctionParseResultArgument>(new LiteralArgument(result.Value!))
+                ? Result.Success<FunctionParseResultArgument>(new LiteralArgument(result.Value!.ToString(formatProvider)))
                 : Result.FromExistingResult<FunctionParseResultArgument>(result);
         }
 

--- a/src/CrossCutting.Utilities.Parsers/GlobalUsings.cs
+++ b/src/CrossCutting.Utilities.Parsers/GlobalUsings.cs
@@ -1,5 +1,6 @@
 ﻿global using System;
 global using System.Collections.Generic;
+global using System.Collections.ObjectModel;
 global using System.Globalization;
 global using System.IO;
 global using System.Linq;

--- a/src/CrossCutting.Utilities.Parsers/PlaceholderProcessors/ExpressionStringPlaceholderProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/PlaceholderProcessors/ExpressionStringPlaceholderProcessor.cs
@@ -13,17 +13,15 @@ public class ExpressionStringPlaceholderProcessor : IPlaceholderProcessor
 
     public int Order => 990;
 
-    public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+    public Result<FormattableStringParserResult> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
     {
         var result = _expressionStringParser.Parse($"={value}", formatProvider, context, formattableStringParser);
 
         if (result.Status == ResultStatus.NotFound)
         {
-            return Result.Continue<string>();
+            return Result.Continue<FormattableStringParserResult>();
         }
 
-        return Result.FromExistingResult(
-            result,
-            value => value.ToString(formatProvider, string.Empty));
+        return Result.FromExistingResult(result, value => new FormattableStringParserResult(value));
     }
 }

--- a/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
+++ b/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Pipelines:
- Breaking change: Do not expose pipeline components on the IPipeline interface. Instead, DO expose the components on the IPipelineBuilder interface instead.
- Made the pipeline and pipeline component async
- Bumped version number of ProcessingPipeline from 5 to 6

Parsers:
- FormattableStringParser now returns a formattable string, so you can have the arguments as objects, and format them later
- Bumped version number of Parsers from 4 to 5

Common:
- Fix: Result.TryCast should retain status, error messages and validation messages
- Added SelectAsync extension method
- Added TransformValue method to Result, to convert or transform the value of the result while retaining status, error message and validation errors
- Bumped version from 3.8.0 to 3.9.0 for CrossCutting.Common and its dependencies