### PR TITLE
Add InnerResults property to Result, and aggregate non-succesful results in ProcessingPipeline

### DIFF
--- a/src/CrossCutting.Common.Tests/Results/ResultTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/ResultTests.cs
@@ -273,6 +273,21 @@ public class ResultTests
     }
 
     [Fact]
+    public void Can_Create_Invalid_Result_With_ErrorMessage_And_InnerResults()
+    {
+        // Act
+        var actual = Result.Invalid<string>("Error", new[] { Result.Error("Kaboom") });
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.IsSuccessful().Should().BeFalse();
+        actual.ErrorMessage.Should().Be("Error");
+        actual.ValidationErrors.Should().BeEmpty();
+        actual.InnerResults.Should().ContainSingle();
+        actual.Value.Should().BeNull();
+    }
+
+    [Fact]
     public void Can_Create_Invalid_Void_Result_With_ErrorMessage()
     {
         // Act
@@ -283,6 +298,20 @@ public class ResultTests
         actual.IsSuccessful().Should().BeFalse();
         actual.ErrorMessage.Should().Be("Error");
         actual.ValidationErrors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Can_Create_Invalid_Void_Result_With_ErrorMessage_And_InnerResults()
+    {
+        // Act
+        var actual = Result.Invalid("Error", new[] { Result.Error("Kaboom") });
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.IsSuccessful().Should().BeFalse();
+        actual.ErrorMessage.Should().Be("Error");
+        actual.ValidationErrors.Should().BeEmpty();
+        actual.InnerResults.Should().ContainSingle();
     }
 
     [Fact]
@@ -424,6 +453,22 @@ public class ResultTests
     }
 
     [Fact]
+    public void Can_Create_Error_Result_With_ErrorMessage_And_InnerResults()
+    {
+        // Act
+        var actual = Result.Error<string>([Result.Error("InnerError")], "Error");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Error);
+        actual.IsSuccessful().Should().BeFalse();
+        actual.ErrorMessage.Should().Be("Error");
+        actual.ValidationErrors.Should().BeEmpty();
+        actual.Value.Should().BeNull();
+        actual.Exception.Should().BeNull();
+        actual.InnerResults.Should().ContainSingle();
+    }
+
+    [Fact]
     public void Can_Create_Error_Void_Result_With_ErrorMessage()
     {
         // Act
@@ -448,6 +493,21 @@ public class ResultTests
         actual.ErrorMessage.Should().Be("Error");
         actual.ValidationErrors.Should().BeEmpty();
         actual.Exception.Should().BeOfType<InvalidOperationException>().And.Match<InvalidOperationException>(x => x.Message == "Kaboom");
+    }
+
+    [Fact]
+    public void Can_Create_Error_Void_Result_With_ErrorMessage_And_InnerResults()
+    {
+        // Act
+        var actual = Result.Error([Result.Error("InnerError")], "Error");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Error);
+        actual.IsSuccessful().Should().BeFalse();
+        actual.ErrorMessage.Should().Be("Error");
+        actual.ValidationErrors.Should().BeEmpty();
+        actual.Exception.Should().BeNull();
+        actual.InnerResults.Should().ContainSingle();
     }
 
     [Fact]
@@ -979,6 +1039,21 @@ public class ResultTests
     }
 
     [Fact]
+    public void Can_Create_Conflict_Result_With_ErrorMessage_And_InnerResult()
+    {
+        // Act
+        var actual = Result.Conflict<string>([Result.Error("Kaboom")], "There is a huge conflict");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Conflict);
+        actual.IsSuccessful().Should().BeFalse();
+        actual.ErrorMessage.Should().Be("There is a huge conflict");
+        actual.ValidationErrors.Should().BeEmpty();
+        actual.Value.Should().BeNull();
+        actual.InnerResults.Should().ContainSingle();
+    }
+
+    [Fact]
     public void Can_Create_Conflict_Void_Result_With_ErrorMessage()
     {
         // Act
@@ -989,6 +1064,20 @@ public class ResultTests
         actual.IsSuccessful().Should().BeFalse();
         actual.ErrorMessage.Should().Be("There is a huge conflict");
         actual.ValidationErrors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Can_Create_Conflict_Void_Result_With_ErrorMessage_And_InnerResult()
+    {
+        // Act
+        var actual = Result.Conflict([Result.Error("Kaboom")], "There is a huge conflict");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Conflict);
+        actual.IsSuccessful().Should().BeFalse();
+        actual.ErrorMessage.Should().Be("There is a huge conflict");
+        actual.ValidationErrors.Should().BeEmpty();
+        actual.InnerResults.Should().ContainSingle();
     }
 
     [Fact]
@@ -1297,8 +1386,8 @@ public class ResultTests
 
         // Assert
         result.Status.Should().Be(ResultStatus.Error);
-        result.ErrorMessage.Should().Be("Kaboom");
-        result.InnerResults.Should().BeEmpty();
+        result.ErrorMessage.Should().Be("Something went wrong. See inner results.");
+        result.InnerResults.Should().ContainSingle();
     }
 
     [Fact]

--- a/src/CrossCutting.Common.Tests/Results/ResultTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/ResultTests.cs
@@ -1251,4 +1251,70 @@ public class ResultTests
         result.ErrorMessage.Should().Be("Kaboom!");
         result.Value.Should().BeNull();
     }
+
+    [Fact]
+    public void Aggregate_Returns_Success_When_No_Items_Are_Present_No_Value()
+    {
+        // Arrange
+        var innerResults = Array.Empty<Result>();
+        var successResult = Result.Success();
+        var errorResultDelegate = new Func<Result[], Result>(errors => Result.Error(errors, "Something went wrong. See inner results."));
+
+        // Act
+        var result = Result.Aggregate(innerResults, successResult, errorResultDelegate);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.InnerResults.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Aggregate_Returns_Success_When_No_Errors_Are_Present_No_Value()
+    {
+        // Arrange
+        var innerResults = new Result[] { Result.Success(), Result.Success() };
+        var successResult = Result.Success();
+        var errorResultDelegate = new Func<Result[], Result>(errors => Result.Error(errors, "Something went wrong. See inner results."));
+
+        // Act
+        var result = Result.Aggregate(innerResults, successResult, errorResultDelegate);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.InnerResults.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Aggregate_Returns_Aggregate_Error_When_One_Item_Is_Not_Succesful_No_Value()
+    {
+        // Arrange
+        var innerResults = new Result[] { Result.Success(), Result.Error("Kaboom") };
+        var successResult = Result.Success();
+        var errorResultDelegate = new Func<Result[], Result>(errors => Result.Error(errors, "Something went wrong. See inner results."));
+
+        // Act
+        var result = Result.Aggregate(innerResults, successResult, errorResultDelegate);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Kaboom");
+        result.InnerResults.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Aggregate_Returns_Aggregate_Error_With_InnerResults_When_Two_Items_Are_Not_Succesful_No_Value()
+    {
+        // Arrange
+        var innerResults = new Result[] { Result.Error("Kaboom 1"), Result.Error("Kaboom 2") };
+        var successResult = Result.Success();
+        var errorResultDelegate = new Func<Result[], Result>(errors => Result.Error(errors, "Something went wrong. See inner results."));
+
+        // Act
+        var result = Result.Aggregate(innerResults, successResult, errorResultDelegate);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Something went wrong. See inner results.");
+        result.InnerResults.Should().HaveCount(2);
+    }
 }

--- a/src/CrossCutting.Common/CrossCutting.Common.csproj
+++ b/src/CrossCutting.Common/CrossCutting.Common.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Common</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.9.0</Version>
-    <PackageVersion>3.9.0</PackageVersion>
+    <Version>3.10.0</Version>
+    <PackageVersion>3.10.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -99,12 +99,15 @@ public record Result
     public static Result<T> NotFound<T>(string errorMessage) => new(default, ResultStatus.NotFound, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result Invalid() => new(ResultStatus.Invalid, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result Invalid(IEnumerable<ValidationError> validationErrors) => new(ResultStatus.Invalid, null, validationErrors, Enumerable.Empty<Result>(), null);
+    public static Result Invalid(IEnumerable<Result> innerResults) => new(ResultStatus.Invalid, null, Enumerable.Empty<ValidationError>(), innerResults, null);
     public static Result Invalid(string errorMessage) => new(ResultStatus.Invalid, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result Invalid(string errorMessage, IEnumerable<ValidationError> validationErrors) => new(ResultStatus.Invalid, errorMessage, validationErrors, Enumerable.Empty<Result>(), null);
+    public static Result Invalid(string errorMessage, IEnumerable<Result> innerResults) => new(ResultStatus.Invalid, errorMessage, Enumerable.Empty<ValidationError>(), innerResults, null);
     public static Result<T> Invalid<T>() => new(default, ResultStatus.Invalid, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result<T> Invalid<T>(IEnumerable<ValidationError> validationErrors) => new(default, ResultStatus.Invalid, null, validationErrors, Enumerable.Empty<Result>(), null);
     public static Result<T> Invalid<T>(string errorMessage) => new Result<T>(default, ResultStatus.Invalid, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result<T> Invalid<T>(string errorMessage, IEnumerable<ValidationError> validationErrors) => new(default, ResultStatus.Invalid, errorMessage, validationErrors, Enumerable.Empty<Result>(), null);
+    public static Result<T> Invalid<T>(string errorMessage, IEnumerable<Result> innerResults) => new(default, ResultStatus.Invalid, errorMessage, Enumerable.Empty<ValidationError>(), innerResults, null);
     public static Result Unauthorized() => new(ResultStatus.Unauthorized, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result Unauthorized(string errorMessage) => new(ResultStatus.Unauthorized, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result<T> Unauthorized<T>() => new(default, ResultStatus.Unauthorized, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
@@ -138,8 +141,10 @@ public record Result
     public static Result<T> Continue<T>(T value) => new(value, ResultStatus.Continue, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result Conflict() => new(ResultStatus.Conflict, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result Conflict(string errorMessage) => new(ResultStatus.Conflict, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Conflict(IEnumerable<Result> innerResults, string errorMessage) => new(ResultStatus.Conflict, errorMessage, Enumerable.Empty<ValidationError>(), innerResults, null);
     public static Result<T> Conflict<T>() => new(default, ResultStatus.Conflict, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
     public static Result<T> Conflict<T>(string errorMessage) => new(default, ResultStatus.Conflict, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Conflict<T>(IEnumerable<Result> innerResults, string errorMessage) => new(default, ResultStatus.Conflict, errorMessage, Enumerable.Empty<ValidationError>(), innerResults, null);
 
     public static Result<T> Redirect<T>(T value) => new(value, ResultStatus.Redirect, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
 
@@ -199,11 +204,6 @@ public record Result
             return successResult;
         }
 
-        if (errors.Length == 1)
-        {
-            return errors[0];
-        }
-
         return errorResultDelegate(errors);
     }
 
@@ -215,11 +215,6 @@ public record Result
         if (errors.Length == 0)
         {
             return successResult;
-        }
-
-        if (errors.Length == 1)
-        {
-            return FromExistingResult<T>(errors[0]);
         }
 
         return errorResultDelegate(errors);

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -6,11 +6,13 @@ public record Result<T> : Result
                     ResultStatus status,
                     string? errorMessage,
                     IEnumerable<ValidationError> validationErrors,
+                    IEnumerable<Result> innerResults,
                     Exception? exception)
         : base(
             status,
             errorMessage,
             validationErrors,
+            innerResults,
             exception)
         => Value = value;
 
@@ -41,7 +43,7 @@ public record Result<T> : Result
             return Invalid<TCast>(errorMessage ?? $"Could not cast {typeof(T).FullName} to {typeof(TCast).FullName}");
         }
 
-        return new Result<TCast>(castValue, Status, ErrorMessage, ValidationErrors, Exception);
+        return new Result<TCast>(castValue, Status, ErrorMessage, ValidationErrors, InnerResults, Exception);
     }
 
     public Result<TTarget> TransformValue<TTarget>(Func<T, TTarget> transformDelegate)
@@ -53,7 +55,7 @@ public record Result<T> : Result
             return FromExistingResult<TTarget>(this);
         }
 
-        return new Result<TTarget>(transformDelegate(Value!), Status, ErrorMessage, ValidationErrors, Exception);
+        return new Result<TTarget>(transformDelegate(Value!), Status, ErrorMessage, ValidationErrors, InnerResults, Exception);
     }
 }
 
@@ -62,11 +64,13 @@ public record Result
     protected Result(ResultStatus status,
                      string? errorMessage,
                      IEnumerable<ValidationError> validationErrors,
+                     IEnumerable<Result> innerResults,
                      Exception? exception)
     {
         Status = status;
         ErrorMessage = errorMessage;
-        ValidationErrors = new ValueCollection<ValidationError>(validationErrors);
+        ValidationErrors = new ValueCollection<ValidationError>(validationErrors.IsNotNull(nameof(validationErrors)));
+        InnerResults = new ValueCollection<Result>(innerResults.IsNotNull(nameof(innerResults)));
         Exception = exception;
     }
 
@@ -77,67 +81,70 @@ public record Result
     public Exception? Exception { get; }
     public ResultStatus Status { get; }
     public IReadOnlyCollection<ValidationError> ValidationErrors { get; }
+    public IReadOnlyCollection<Result> InnerResults { get; }
 
-    public static Result Success() => new(ResultStatus.Ok, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Success<T>(T value) => new(value, ResultStatus.Ok, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result Error() => new(ResultStatus.Error, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result Error(string errorMessage) => new(ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result Error(Exception exception, string errorMessage) => new(ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), exception);
-    public static Result<T> Error<T>() => new(default, ResultStatus.Error, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Error<T>(string errorMessage) => new(default, ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Error<T>(Exception exception, string errorMessage) => new(default, ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), exception);
-    public static Result NotFound() => new(ResultStatus.NotFound, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result NotFound(string errorMessage) => new(ResultStatus.NotFound, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NotFound<T>() => new(default, ResultStatus.NotFound, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NotFound<T>(string errorMessage) => new(default, ResultStatus.NotFound, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result Invalid() => new(ResultStatus.Invalid, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result Invalid(IEnumerable<ValidationError> validationErrors) => new(ResultStatus.Invalid, null, validationErrors, null);
-    public static Result Invalid(string errorMessage) => new(ResultStatus.Invalid, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result Invalid(string errorMessage, IEnumerable<ValidationError> validationErrors) => new(ResultStatus.Invalid, errorMessage, validationErrors, null);
-    public static Result<T> Invalid<T>() => new(default, ResultStatus.Invalid, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Invalid<T>(IEnumerable<ValidationError> validationErrors) => new(default, ResultStatus.Invalid, null, validationErrors, null);
-    public static Result<T> Invalid<T>(string errorMessage) => new Result<T>(default, ResultStatus.Invalid, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Invalid<T>(string errorMessage, IEnumerable<ValidationError> validationErrors) => new(default, ResultStatus.Invalid, errorMessage, validationErrors, null);
-    public static Result Unauthorized() => new(ResultStatus.Unauthorized, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result Unauthorized(string errorMessage) => new(ResultStatus.Unauthorized, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Unauthorized<T>() => new(default, ResultStatus.Unauthorized, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Unauthorized<T>(string errorMessage) => new(default, ResultStatus.Unauthorized, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result NotAuthenticated() => new(ResultStatus.NotAuthenticated, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result NotAuthenticated(string errorMessage) => new(ResultStatus.NotAuthenticated, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NotAuthenticated<T>() => new(default, ResultStatus.NotAuthenticated, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NotAuthenticated<T>(string errorMessage) => new(default, ResultStatus.NotAuthenticated, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result NotSupported() => new(ResultStatus.NotSupported, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result NotSupported(string errorMessage) => new(ResultStatus.NotSupported, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NotSupported<T>() => new(default, ResultStatus.NotSupported, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NotSupported<T>(string errorMessage) => new(default, ResultStatus.NotSupported, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result Unavailable() => new(ResultStatus.Unavailable, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result Unavailable(string errorMessage) => new(ResultStatus.Unavailable, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Unavailable<T>() => new(default, ResultStatus.Unavailable, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Unavailable<T>(string errorMessage) => new(default, ResultStatus.Unavailable, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result NotImplemented() => new(ResultStatus.NotImplemented, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result NotImplemented(string errorMessage) => new(ResultStatus.NotImplemented, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NotImplemented<T>() => new(default, ResultStatus.NotImplemented, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NotImplemented<T>(string errorMessage) => new(default, ResultStatus.NotImplemented, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result NoContent() => new(ResultStatus.NoContent, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result NoContent(string errorMessage) => new(ResultStatus.NoContent, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NoContent<T>() => new(default, ResultStatus.NoContent, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> NoContent<T>(string errorMessage) => new(default, ResultStatus.NoContent, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result ResetContent() => new(ResultStatus.ResetContent, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result ResetContent(string errorMessage) => new(ResultStatus.ResetContent, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> ResetContent<T>() => new(default, ResultStatus.ResetContent, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> ResetContent<T>(string errorMessage) => new(default, ResultStatus.ResetContent, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result Continue() => new(ResultStatus.Continue, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Continue<T>() => new(default, ResultStatus.Continue, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Continue<T>(T value) => new(value, ResultStatus.Continue, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result Conflict() => new(ResultStatus.Conflict, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result Conflict(string errorMessage) => new(ResultStatus.Conflict, errorMessage, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Conflict<T>() => new(default, ResultStatus.Conflict, null, Enumerable.Empty<ValidationError>(), null);
-    public static Result<T> Conflict<T>(string errorMessage) => new(default, ResultStatus.Conflict, errorMessage, Enumerable.Empty<ValidationError>(), null);
+    public static Result Success() => new(ResultStatus.Ok, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Success<T>(T value) => new(value, ResultStatus.Ok, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Error() => new(ResultStatus.Error, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Error(string errorMessage) => new(ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Error(Exception exception, string errorMessage) => new(ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), exception);
+    public static Result Error(IEnumerable<Result> innerResults, string errorMessage) => new(ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), innerResults, null);
+    public static Result<T> Error<T>() => new(default, ResultStatus.Error, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Error<T>(string errorMessage) => new(default, ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Error<T>(Exception exception, string errorMessage) => new(default, ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), exception);
+    public static Result<T> Error<T>(IEnumerable<Result> innerResults, string errorMessage) => new(default, ResultStatus.Error, errorMessage, Enumerable.Empty<ValidationError>(), innerResults, null);
+    public static Result NotFound() => new(ResultStatus.NotFound, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NotFound(string errorMessage) => new(ResultStatus.NotFound, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NotFound<T>() => new(default, ResultStatus.NotFound, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NotFound<T>(string errorMessage) => new(default, ResultStatus.NotFound, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Invalid() => new(ResultStatus.Invalid, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Invalid(IEnumerable<ValidationError> validationErrors) => new(ResultStatus.Invalid, null, validationErrors, Enumerable.Empty<Result>(), null);
+    public static Result Invalid(string errorMessage) => new(ResultStatus.Invalid, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Invalid(string errorMessage, IEnumerable<ValidationError> validationErrors) => new(ResultStatus.Invalid, errorMessage, validationErrors, Enumerable.Empty<Result>(), null);
+    public static Result<T> Invalid<T>() => new(default, ResultStatus.Invalid, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Invalid<T>(IEnumerable<ValidationError> validationErrors) => new(default, ResultStatus.Invalid, null, validationErrors, Enumerable.Empty<Result>(), null);
+    public static Result<T> Invalid<T>(string errorMessage) => new Result<T>(default, ResultStatus.Invalid, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Invalid<T>(string errorMessage, IEnumerable<ValidationError> validationErrors) => new(default, ResultStatus.Invalid, errorMessage, validationErrors, Enumerable.Empty<Result>(), null);
+    public static Result Unauthorized() => new(ResultStatus.Unauthorized, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Unauthorized(string errorMessage) => new(ResultStatus.Unauthorized, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Unauthorized<T>() => new(default, ResultStatus.Unauthorized, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Unauthorized<T>(string errorMessage) => new(default, ResultStatus.Unauthorized, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NotAuthenticated() => new(ResultStatus.NotAuthenticated, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NotAuthenticated(string errorMessage) => new(ResultStatus.NotAuthenticated, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NotAuthenticated<T>() => new(default, ResultStatus.NotAuthenticated, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NotAuthenticated<T>(string errorMessage) => new(default, ResultStatus.NotAuthenticated, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NotSupported() => new(ResultStatus.NotSupported, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NotSupported(string errorMessage) => new(ResultStatus.NotSupported, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NotSupported<T>() => new(default, ResultStatus.NotSupported, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NotSupported<T>(string errorMessage) => new(default, ResultStatus.NotSupported, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Unavailable() => new(ResultStatus.Unavailable, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Unavailable(string errorMessage) => new(ResultStatus.Unavailable, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Unavailable<T>() => new(default, ResultStatus.Unavailable, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Unavailable<T>(string errorMessage) => new(default, ResultStatus.Unavailable, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NotImplemented() => new(ResultStatus.NotImplemented, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NotImplemented(string errorMessage) => new(ResultStatus.NotImplemented, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NotImplemented<T>() => new(default, ResultStatus.NotImplemented, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NotImplemented<T>(string errorMessage) => new(default, ResultStatus.NotImplemented, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NoContent() => new(ResultStatus.NoContent, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result NoContent(string errorMessage) => new(ResultStatus.NoContent, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NoContent<T>() => new(default, ResultStatus.NoContent, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> NoContent<T>(string errorMessage) => new(default, ResultStatus.NoContent, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result ResetContent() => new(ResultStatus.ResetContent, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result ResetContent(string errorMessage) => new(ResultStatus.ResetContent, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> ResetContent<T>() => new(default, ResultStatus.ResetContent, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> ResetContent<T>(string errorMessage) => new(default, ResultStatus.ResetContent, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Continue() => new(ResultStatus.Continue, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Continue<T>() => new(default, ResultStatus.Continue, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Continue<T>(T value) => new(value, ResultStatus.Continue, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Conflict() => new(ResultStatus.Conflict, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result Conflict(string errorMessage) => new(ResultStatus.Conflict, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Conflict<T>() => new(default, ResultStatus.Conflict, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
+    public static Result<T> Conflict<T>(string errorMessage) => new(default, ResultStatus.Conflict, errorMessage, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
 
-    public static Result<T> Redirect<T>(T value) => new(value, ResultStatus.Redirect, null, Enumerable.Empty<ValidationError>(), null);
+    public static Result<T> Redirect<T>(T value) => new(value, ResultStatus.Redirect, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
 
-    public static Result<T> FromExistingResult<T>(Result existingResult) => new(TryGetValue<T>(ArgumentGuard.IsNotNull(existingResult, nameof(existingResult))), existingResult.Status, existingResult.ErrorMessage, existingResult.ValidationErrors, null);
-    public static Result<T> FromExistingResult<T>(Result existingResult, T value) => new(value, ArgumentGuard.IsNotNull(existingResult, nameof(existingResult)).Status, existingResult.ErrorMessage, existingResult.ValidationErrors, null);
+    public static Result<T> FromExistingResult<T>(Result existingResult) => new(TryGetValue<T>(ArgumentGuard.IsNotNull(existingResult, nameof(existingResult))), existingResult.Status, existingResult.ErrorMessage, existingResult.ValidationErrors, existingResult.InnerResults, null);
+    public static Result<T> FromExistingResult<T>(Result existingResult, T value) => new(value, ArgumentGuard.IsNotNull(existingResult, nameof(existingResult)).Status, existingResult.ErrorMessage, existingResult.ValidationErrors, existingResult.InnerResults, null);
     public static Result<TTargetResult> FromExistingResult<TSourceResult, TTargetResult>(Result<TSourceResult> existingResult, Func<TSourceResult, TTargetResult> convertDelegate)
     {
         ArgumentGuard.IsNotNull(existingResult, nameof(existingResult));
@@ -181,6 +188,42 @@ public record Result
         => validationErrors.Any()
             ? Invalid(errorMessage, validationErrors)
             : Success();
+
+    public static Result Aggregate(IEnumerable<Result> innerResults, Result successResult, Func<Result[], Result> errorResultDelegate)
+    {
+        ArgumentGuard.IsNotNull(errorResultDelegate, nameof(errorResultDelegate));
+
+        var errors = innerResults.Where(x => !x.IsSuccessful()).ToArray();
+        if (errors.Length == 0)
+        {
+            return successResult;
+        }
+
+        if (errors.Length == 1)
+        {
+            return errors[0];
+        }
+
+        return errorResultDelegate(errors);
+    }
+
+    public static Result<T> Aggregate<T>(IEnumerable<Result> innerResults, Result<T> successResult, Func<Result[], Result<T>> errorResultDelegate)
+    {
+        ArgumentGuard.IsNotNull(errorResultDelegate, nameof(errorResultDelegate));
+
+        var errors = innerResults.Where(x => !x.IsSuccessful()).ToArray();
+        if (errors.Length == 0)
+        {
+            return successResult;
+        }
+
+        if (errors.Length == 1)
+        {
+            return FromExistingResult<T>(errors[0]);
+        }
+
+        return errorResultDelegate(errors);
+    }
 
     private static T? TryGetValue<T>(Result existingResult) => existingResult.GetValue() is T t
         ? t

--- a/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
+++ b/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Data.Core</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>4.0.0</Version>
-    <PackageVersion>4.0.0</PackageVersion>
+    <Version>4.1.0</Version>
+    <PackageVersion>4.1.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Data.Sql/CrossCutting.Data.Sql.csproj
+++ b/src/CrossCutting.Data.Sql/CrossCutting.Data.Sql.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Data.Sql</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>5.0.0</Version>
-    <PackageVersion>5.0.0</PackageVersion>
+    <Version>5.1.0</Version>
+    <PackageVersion>5.1.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
+++ b/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.DataTableDumper</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.9.0</Version>
-    <PackageVersion>3.9.0</PackageVersion>
+    <Version>3.10.0</Version>
+    <PackageVersion>3.10.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
+++ b/src/CrossCutting.ProcessingPipeline.Tests/ProofOfConceptTests.cs
@@ -167,7 +167,7 @@ public class ProofOfConceptTests
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
-            result.ErrorMessage.Should().Be("Kaboom");
+            result.ErrorMessage.Should().Be("An error occured while processing the pipeline. See the inner results for more details.");
         }
 
         [Fact]
@@ -184,7 +184,7 @@ public class ProofOfConceptTests
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
-            result.ErrorMessage.Should().Be("Kaboom");
+            result.ErrorMessage.Should().Be("An error occured while processing the pipeline. See the inner results for more details.");
         }
         [Fact]
         public void Constructing_Pipeline_Using_Null_ValidationDelegate_Throws_ArgumentNullException()
@@ -376,7 +376,24 @@ public class ProofOfConceptTests
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
-            result.ErrorMessage.Should().Be("Kaboom");
+            result.ErrorMessage.Should().Be("An error occured while processing the pipeline. See the inner results for more details.");
+        }
+
+        [Fact]
+        public async Task Can_Abort_Pipeline_With_Feature_Using_Non_Success_Status_And_CancellationToken()
+        {
+            // Arrange
+            Func<PipelineContext<object?>, Result<object?>> processCallback = new(_ => Result.Error<object?>("Kaboom"));
+            var sut = new PipelineBuilder<object?>()
+                .AddComponent(new MyResponselessComponentBuilder().WithProcessCallback(processCallback))
+                .Build();
+
+            // Act
+            var result = await sut.Process(request: 1, new CancellationToken());
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Error);
+            result.ErrorMessage.Should().Be("An error occured while processing the pipeline. See the inner results for more details.");
         }
 
         [Fact]

--- a/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
+++ b/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.ProcessingPipeline</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>8.0.0</Version>
-    <PackageVersion>8.0.0</PackageVersion>
+    <Version>8.1.0</Version>
+    <PackageVersion>8.1.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Utilities.Aggregators/CrossCutting.Utilities.Aggregators.csproj
+++ b/src/CrossCutting.Utilities.Aggregators/CrossCutting.Utilities.Aggregators.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Aggregators</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.9.0</Version>
-    <PackageVersion>3.9.0</PackageVersion>
+    <Version>3.10.0</Version>
+    <PackageVersion>3.10.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Utilities.ObjectDumper/CrossCutting.Utilities.ObjectDumper.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper/CrossCutting.Utilities.ObjectDumper.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Utilities.ObjectDumper</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.9.0</Version>
-    <PackageVersion>3.9.0</PackageVersion>
+    <Version>3.10.0</Version>
+    <PackageVersion>3.10.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Utilities.Operators/CrossCutting.Utilities.Operators.csproj
+++ b/src/CrossCutting.Utilities.Operators/CrossCutting.Utilities.Operators.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Operators</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.9.0</Version>
-    <PackageVersion>3.9.0</PackageVersion>
+    <Version>3.10.0</Version>
+    <PackageVersion>3.10.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
+++ b/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Parsers</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>5.0.0</Version>
-    <PackageVersion>5.0.0</PackageVersion>
+    <Version>5.1.0</Version>
+    <PackageVersion>5.1.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- The Result class now has an InnerResults property, which can be filled in case of errors or invalid results (validation errors).
- In the ProcessingPipeline, now all results are returned in an aggregate result on non one or more non succesful results.