### PR TITLE
Minor refactoring

### DIFF
--- a/src/CrossCutting.CodeGeneration/CodeGenerationProviders/CrossCuttingCSharpClassBase.cs
+++ b/src/CrossCutting.CodeGeneration/CodeGenerationProviders/CrossCuttingCSharpClassBase.cs
@@ -23,12 +23,13 @@ public abstract class CrossCuttingCSharpClassBase : CsharpClassGeneratorPipeline
 
     protected override bool IsAbstractType(Type type)
     {
-        type = type.IsNotNull(nameof(type));
+        ArgumentGuard.IsNotNull(type, nameof(type));
 
         if (type.IsInterface && type.Namespace == $"{CodeGenerationRootNamespace}.Models" && type.Name.Substring(1) == Constants.Types.FunctionParseResultArgument)
         {
             return true;
         }
+
         return base.IsAbstractType(type);
     }
 

--- a/src/CrossCutting.CodeGeneration/CodeGenerationProviders/CrossCuttingCSharpClassBase.cs
+++ b/src/CrossCutting.CodeGeneration/CodeGenerationProviders/CrossCuttingCSharpClassBase.cs
@@ -20,6 +20,7 @@ public abstract class CrossCuttingCSharpClassBase : CsharpClassGeneratorPipeline
     protected override bool CopyInterfaces => true;
     protected override bool CreateRecord => true;
     protected override bool GenerateMultipleFiles => false;
+    protected override bool EnableGlobalUsings => true;
 
     protected override bool IsAbstractType(Type type)
     {

--- a/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
+++ b/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.15.3" />
-    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="1.0.2" />
+    <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.15.5" />
+    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
+++ b/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.16.0" />
+    <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.16.1" />
     <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="1.0.3" />
   </ItemGroup>
 

--- a/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
+++ b/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.15.5" />
+    <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.16.0" />
     <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="1.0.3" />
   </ItemGroup>
 

--- a/src/CrossCutting.Common/Abstractions/IBuilder.cs
+++ b/src/CrossCutting.Common/Abstractions/IBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace CrossCutting.ProcessingPipeline;
+﻿namespace CrossCutting.Common.Abstractions;
 
 public interface IBuilder<out T>
 {

--- a/src/CrossCutting.Common/Extensions/EnumerableExtensions.cs
+++ b/src/CrossCutting.Common/Extensions/EnumerableExtensions.cs
@@ -108,8 +108,8 @@ public static class EnumerableExtensions
 
     public static Result PerformUntilFailure<T>(this IEnumerable<T> instance, Func<Result> defaultValueDelegate, Func<T, Result> actionDelegate)
     {
-        defaultValueDelegate = defaultValueDelegate.IsNotNull(nameof(defaultValueDelegate));
-        actionDelegate = actionDelegate.IsNotNull(nameof(actionDelegate));
+        ArgumentGuard.IsNotNull(defaultValueDelegate, nameof(defaultValueDelegate));
+        ArgumentGuard.IsNotNull(actionDelegate, nameof(actionDelegate));
 
         return instance
             .Select(x => actionDelegate(x))
@@ -122,8 +122,8 @@ public static class EnumerableExtensions
 
     public static async Task<Result> PerformUntilFailure<T>(this IEnumerable<T> instance, Func<Result> defaultValueDelegate, Func<T, Task<Result>> actionDelegate)
     {
-        defaultValueDelegate = defaultValueDelegate.IsNotNull(nameof(defaultValueDelegate));
-        actionDelegate = actionDelegate.IsNotNull(nameof(actionDelegate));
+        ArgumentGuard.IsNotNull(defaultValueDelegate, nameof(defaultValueDelegate));
+        ArgumentGuard.IsNotNull(actionDelegate, nameof(actionDelegate));
 
         foreach (var item in instance)
         {
@@ -142,8 +142,8 @@ public static class EnumerableExtensions
 
     public static async Task<Result> PerformUntilFailure(this IEnumerable instance, Func<Result> defaultValueDelegate, Func<object, Task<Result>> actionDelegate)
     {
-        defaultValueDelegate = defaultValueDelegate.IsNotNull(nameof(defaultValueDelegate));
-        actionDelegate = actionDelegate.IsNotNull(nameof(actionDelegate));
+        ArgumentGuard.IsNotNull(defaultValueDelegate, nameof(defaultValueDelegate));
+        ArgumentGuard.IsNotNull(actionDelegate, nameof(actionDelegate));
 
         foreach (var item in instance)
         {

--- a/src/CrossCutting.Common/Extensions/ObjectExtensions.cs
+++ b/src/CrossCutting.Common/Extensions/ObjectExtensions.cs
@@ -54,7 +54,11 @@ public static class ObjectExtensions
     /// value.ToString() when te value is not null, defaultValueDelegate result otherwise.
     /// </returns>
     public static string ToStringWithDefault(this object? value, Func<string> defaultValueDelegate)
-        => value.ToStringWithDefault(ArgumentGuard.IsNotNull(defaultValueDelegate, nameof(defaultValueDelegate)).Invoke());
+    {
+        ArgumentGuard.IsNotNull(defaultValueDelegate, nameof(defaultValueDelegate));
+
+        return value.ToStringWithDefault(defaultValueDelegate.Invoke());
+    }
 
     /// <summary>
     /// Converts an object value to string with default value if null.
@@ -176,7 +180,11 @@ public static class ObjectExtensions
     }
 
     public static TTarget Transform<TSource, TTarget>(this TSource instance, Func<TSource, TTarget> transformDelegate)
-        => ArgumentGuard.IsNotNull(transformDelegate, nameof(transformDelegate)).Invoke(instance);
+    {
+        ArgumentGuard.IsNotNull(transformDelegate, nameof(transformDelegate));
+        
+        return transformDelegate.Invoke(instance);
+    }
 
     public static T With<T>(this T instance, Action<T> action)
     {

--- a/src/CrossCutting.Common/Extensions/ResultExtensions.cs
+++ b/src/CrossCutting.Common/Extensions/ResultExtensions.cs
@@ -5,8 +5,8 @@ public static class ResultExtensions
     public static void Either<T>(this T instance, Action<T> errorDelegate, Action<T> successDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -20,8 +20,8 @@ public static class ResultExtensions
     public static Task<T> Either<T>(this T instance, Action<T> errorDelegate, Func<T, Task<T>> successDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -35,8 +35,8 @@ public static class ResultExtensions
     public static void Either<T>(this T instance, Action<T> errorDelegate, Action successDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -50,8 +50,8 @@ public static class ResultExtensions
     public static Task<T> Either<T>(this T instance, Action<T> errorDelegate, Func<Task<T>> successDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -65,8 +65,8 @@ public static class ResultExtensions
     public static T Either<T>(this T instance, Func<T, T> errorDelegate, Func<T, T> successDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -79,8 +79,8 @@ public static class ResultExtensions
     public static Task<T> Either<T>(this T instance, Func<T, T> errorDelegate, Func<T, Task<T>> successDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -93,8 +93,8 @@ public static class ResultExtensions
     public static T Either<T>(this T instance, Func<T, T> errorDelegate, Func<T> successDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -107,8 +107,8 @@ public static class ResultExtensions
     public static Task<T> Either<T>(this T instance, Func<T, T> errorDelegate, Func<Task<T>> successDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -121,7 +121,7 @@ public static class ResultExtensions
     public static T OnFailure<T>(this T instance, Action errorDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -134,7 +134,7 @@ public static class ResultExtensions
     public static T OnFailure<T>(this T instance, Action<T> errorDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -147,7 +147,7 @@ public static class ResultExtensions
     public static T OnFailure<T>(this T instance, Func<T> errorDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -160,7 +160,7 @@ public static class ResultExtensions
     public static Task<T> OnFailure<T>(this T instance, Func<Task<T>> errorDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -173,7 +173,7 @@ public static class ResultExtensions
     public static T OnFailure<T>(this T instance, Func<T, T> errorDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -186,7 +186,7 @@ public static class ResultExtensions
     public static Task<T> OnFailure<T>(this T instance, Func<T, Task<T>> errorDelegate)
         where T : Result
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
 
         if (!instance.IsSuccessful())
         {
@@ -199,7 +199,7 @@ public static class ResultExtensions
     public static T OnSuccess<T>(this T instance, Action successDelegate)
     where T : Result
     {
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (instance.IsSuccessful())
         {
@@ -212,7 +212,7 @@ public static class ResultExtensions
     public static T OnSuccess<T>(this T instance, Action<T> successDelegate)
         where T : Result
     {
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (instance.IsSuccessful())
         {
@@ -225,7 +225,7 @@ public static class ResultExtensions
     public static T OnSuccess<T>(this T instance, Func<T> successDelegate)
         where T : Result
     {
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (instance.IsSuccessful())
         {
@@ -238,7 +238,7 @@ public static class ResultExtensions
     public static Task<T> OnSuccess<T>(this T instance, Func<Task<T>> successDelegate)
         where T : Result
     {
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (instance.IsSuccessful())
         {
@@ -251,7 +251,7 @@ public static class ResultExtensions
     public static T OnSuccess<T>(this T instance, Func<T, T> successDelegate)
         where T : Result
     {
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (instance.IsSuccessful())
         {
@@ -264,7 +264,7 @@ public static class ResultExtensions
     public static Task<T> OnSuccess<T>(this T instance, Func<T, Task<T>> successDelegate)
         where T : Result
     {
-        successDelegate = successDelegate.IsNotNull(nameof(successDelegate));
+        ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
 
         if (instance.IsSuccessful())
         {

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -60,7 +60,7 @@ public record Result<T> : Result
 
     public Result<T> Either(Func<Result<T>, Result<T>> errorDelegate)
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
 
         if (!IsSuccessful())
         {
@@ -333,7 +333,7 @@ public record Result
 
     public Result Either(Func<Result, Result> errorDelegate)
     {
-        errorDelegate = errorDelegate.IsNotNull(nameof(errorDelegate));
+        ArgumentGuard.IsNotNull(errorDelegate, nameof(errorDelegate));
 
         if (!IsSuccessful())
         {

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -79,10 +79,13 @@ public record Result
                      IEnumerable<Result> innerResults,
                      Exception? exception)
     {
+        ArgumentGuard.IsNotNull(validationErrors, nameof(validationErrors));
+        ArgumentGuard.IsNotNull(innerResults, nameof(innerResults));
+
         Status = status;
         ErrorMessage = errorMessage;
-        ValidationErrors = new ValueCollection<ValidationError>(validationErrors.IsNotNull(nameof(validationErrors)));
-        InnerResults = new ValueCollection<Result>(innerResults.IsNotNull(nameof(innerResults)));
+        ValidationErrors = new ValueCollection<ValidationError>(validationErrors);
+        InnerResults = new ValueCollection<Result>(innerResults);
         Exception = exception;
     }
 
@@ -242,8 +245,20 @@ public record Result
 
     public static Result<T> Redirect<T>(T value) => new(value, ResultStatus.Redirect, null, Enumerable.Empty<ValidationError>(), Enumerable.Empty<Result>(), null);
 
-    public static Result<T> FromExistingResult<T>(Result existingResult) => new(TryGetValue<T>(ArgumentGuard.IsNotNull(existingResult, nameof(existingResult))), existingResult.Status, existingResult.ErrorMessage, existingResult.ValidationErrors, existingResult.InnerResults, null);
-    public static Result<T> FromExistingResult<T>(Result existingResult, T value) => new(value, ArgumentGuard.IsNotNull(existingResult, nameof(existingResult)).Status, existingResult.ErrorMessage, existingResult.ValidationErrors, existingResult.InnerResults, null);
+    public static Result<T> FromExistingResult<T>(Result existingResult)
+    {
+        ArgumentGuard.IsNotNull(existingResult, nameof(existingResult));
+
+        return new(TryGetValue<T>(existingResult), existingResult.Status, existingResult.ErrorMessage, existingResult.ValidationErrors, existingResult.InnerResults, null);
+    }
+
+    public static Result<T> FromExistingResult<T>(Result existingResult, T value)
+    {
+        ArgumentGuard.IsNotNull(existingResult, nameof(existingResult));
+
+        return new(value, existingResult.Status, existingResult.ErrorMessage, existingResult.ValidationErrors, existingResult.InnerResults, null);
+    }
+
     public static Result<TTargetResult> FromExistingResult<TSourceResult, TTargetResult>(Result<TSourceResult> existingResult, Func<TSourceResult, TTargetResult> convertDelegate)
     {
         ArgumentGuard.IsNotNull(existingResult, nameof(existingResult));

--- a/src/CrossCutting.ProcessingPipeline.Tests/GlobalUsings.cs
+++ b/src/CrossCutting.ProcessingPipeline.Tests/GlobalUsings.cs
@@ -3,6 +3,7 @@ global using System.Text;
 global using AutoFixture;
 global using AutoFixture.AutoNSubstitute;
 global using AutoFixture.Kernel;
+global using CrossCutting.Common.Abstractions;
 global using CrossCutting.Common.DataAnnotations;
 global using CrossCutting.Common.Extensions;
 global using CrossCutting.Common.Results;

--- a/src/CrossCutting.ProcessingPipeline/GlobalUsings.cs
+++ b/src/CrossCutting.ProcessingPipeline/GlobalUsings.cs
@@ -6,6 +6,7 @@ global using System.Linq;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using CrossCutting.Common;
+global using CrossCutting.Common.Abstractions;
 global using CrossCutting.Common.DataAnnotations;
 global using CrossCutting.Common.Extensions;
 global using CrossCutting.Common.Results;

--- a/src/CrossCutting.ProcessingPipeline/Pipeline.cs
+++ b/src/CrossCutting.ProcessingPipeline/Pipeline.cs
@@ -4,14 +4,19 @@ public class Pipeline<TRequest> : PipelineBase<TRequest>, IPipeline<TRequest>
 {
     private readonly Action<TRequest, PipelineContext<TRequest>> _validationDelegate;
 
-    public Pipeline(Action<TRequest, PipelineContext<TRequest>> validationDelegate, IEnumerable<IPipelineComponent<TRequest>> features) : base(features.IsNotNull(nameof(features)))
+    public Pipeline(Action<TRequest, PipelineContext<TRequest>> validationDelegate, IEnumerable<IPipelineComponent<TRequest>> features) : base(features)
     {
-        _validationDelegate = validationDelegate.IsNotNull(nameof(validationDelegate));
+        ArgumentGuard.IsNotNull(validationDelegate, nameof(validationDelegate));
+        ArgumentGuard.IsNotNull(features, nameof(features)); //note that the base class allows null
+
+        _validationDelegate = validationDelegate;
     }
 
     public async Task<Result> Process(TRequest request, CancellationToken token)
     {
-        var pipelineContext = new PipelineContext<TRequest>(ArgumentGuard.IsNotNull(request, nameof(request)));
+        ArgumentGuard.IsNotNull(request, nameof(request));
+
+        var pipelineContext = new PipelineContext<TRequest>(request);
 
         _validationDelegate(request, pipelineContext);
 
@@ -29,14 +34,19 @@ public class Pipeline<TRequest, TResponse> : PipelineBase<TRequest, TResponse>, 
 {
     private readonly Action<TRequest, PipelineContext<TRequest, TResponse>> _validationDelegate;
 
-    public Pipeline(Action<TRequest, PipelineContext<TRequest, TResponse>> validationDelegate, IEnumerable<IPipelineComponent<TRequest, TResponse>> features) : base(features.IsNotNull(nameof(features)))
+    public Pipeline(Action<TRequest, PipelineContext<TRequest, TResponse>> validationDelegate, IEnumerable<IPipelineComponent<TRequest, TResponse>> features) : base(features)
     {
-        _validationDelegate = validationDelegate.IsNotNull(nameof(validationDelegate));
+        ArgumentGuard.IsNotNull(validationDelegate, nameof(validationDelegate));
+        ArgumentGuard.IsNotNull(features, nameof(features)); //note that the base class allows null
+
+        _validationDelegate = validationDelegate;
     }
 
     public async Task<Result<TResponse>> Process(TRequest request, TResponse seed, CancellationToken token)
     {
-        var pipelineContext = new PipelineContext<TRequest, TResponse>(request.IsNotNull(nameof(request)), seed);
+        ArgumentGuard.IsNotNull(request, nameof(request));
+
+        var pipelineContext = new PipelineContext<TRequest, TResponse>(request, seed);
 
         _validationDelegate(request, pipelineContext);
 

--- a/src/CrossCutting.ProcessingPipeline/PipelineBuilderBase.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineBuilderBase.cs
@@ -13,7 +13,11 @@ public abstract class PipelineBuilderBase<T, TResult>
     }
 
     public TResult AddComponents(IEnumerable<IBuilder<T>> components)
-        => AddComponents(components.IsNotNull(nameof(components)).ToArray());
+    {
+        ArgumentGuard.IsNotNull(components, nameof(components));
+
+        return AddComponents(components.ToArray());
+    }
 
     public TResult AddComponents(params IBuilder<T>[] components)
     {
@@ -27,12 +31,19 @@ public abstract class PipelineBuilderBase<T, TResult>
 
     public TResult AddComponent(IBuilder<T> component)
     {
-        Components.Add(component.IsNotNull(nameof(component)));
+        ArgumentGuard.IsNotNull(component, nameof(component));
+
+        Components.Add(component);
+
         return (TResult)this;
     }
 
     public TResult ReplaceComponent<TOriginal>(IBuilder<T> newComponent)
-        => RemoveComponent<TOriginal>().AddComponent(newComponent.IsNotNull(nameof(newComponent)));
+    {
+        ArgumentGuard.IsNotNull(newComponent, nameof(newComponent));
+
+        return RemoveComponent<TOriginal>().AddComponent(newComponent);
+    }
 
     public TResult RemoveComponent<TRemove>()
     {

--- a/src/CrossCutting.ProcessingPipeline/PipelineContext.cs
+++ b/src/CrossCutting.ProcessingPipeline/PipelineContext.cs
@@ -4,7 +4,9 @@ public class PipelineContext<TRequest>
 {
     public PipelineContext(TRequest request)
     {
-        Request = request.IsNotNull(nameof(request));
+        ArgumentGuard.IsNotNull(request, nameof(request));
+
+        Request = request;
     }
 
     public TRequest Request { get; }
@@ -14,7 +16,9 @@ public class PipelineContext<TRequest, TResponse> : PipelineContext<TRequest>
 {
     public PipelineContext(TRequest request, TResponse response) : base(request)
     {
-        Response = response.IsNotNull(nameof(response));
+        ArgumentGuard.IsNotNull(response, nameof(response));
+
+        Response = response;
     }
 
     public TResponse Response { get; }

--- a/src/CrossCutting.Utilities.Parsers/AbstractEntities.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/AbstractEntities.template.generated.cs
@@ -7,11 +7,6 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 #nullable enable
 namespace CrossCutting.Utilities.Parsers
 {

--- a/src/CrossCutting.Utilities.Parsers/Builders/AbstractBuilders.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/AbstractBuilders.template.generated.cs
@@ -7,11 +7,6 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 #nullable enable
 namespace CrossCutting.Utilities.Parsers.Builders
 {

--- a/src/CrossCutting.Utilities.Parsers/Builders/AbstractNonGenericBuilders.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/AbstractNonGenericBuilders.template.generated.cs
@@ -7,11 +7,6 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 #nullable enable
 namespace CrossCutting.Utilities.Parsers.Builders
 {

--- a/src/CrossCutting.Utilities.Parsers/Builders/CoreBuilders.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/CoreBuilders.template.generated.cs
@@ -7,11 +7,6 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 #nullable enable
 namespace CrossCutting.Utilities.Parsers.Builders
 {

--- a/src/CrossCutting.Utilities.Parsers/Builders/FunctionParseResultArguments/OverrideBuilders.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/FunctionParseResultArguments/OverrideBuilders.template.generated.cs
@@ -7,11 +7,6 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 #nullable enable
 namespace CrossCutting.Utilities.Parsers.Builders.FunctionParseResultArguments
 {

--- a/src/CrossCutting.Utilities.Parsers/CoreEntities.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/CoreEntities.template.generated.cs
@@ -7,11 +7,6 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 #nullable enable
 namespace CrossCutting.Utilities.Parsers
 {

--- a/src/CrossCutting.Utilities.Parsers/FunctionParseResultArguments/OverrideEntities.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParseResultArguments/OverrideEntities.template.generated.cs
@@ -7,11 +7,6 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 #nullable enable
 namespace CrossCutting.Utilities.Parsers.FunctionParseResultArguments
 {


### PR DESCRIPTION
Checking to see if not using the result value of ArgumentGuard.IsNotNull does not introduce Sonar warnings.

The better solution would be using ArgumentNullException.ThrowIfNull, but this is not available in .net standard 2.0.