### PR TITLE
Made argument type validation optional

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,3 @@
 TODO
 - Low priority: Refactor ParseResult and ProcessResult (used by some older parsers in this project) to use the regular Result class
 - Low priority: Check whether Validate methods should fill validation results with IEnumerable<ValidationError>. You could still use Result<Type> to return the type...
-
-- Add a setting in FunctionEvaluator to enable or disable type argument checking

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,5 @@
 TODO
 - Low priority: Refactor ParseResult and ProcessResult (used by some older parsers in this project) to use the regular Result class
 - Low priority: Check whether Validate methods should fill validation results with IEnumerable<ValidationError>. You could still use Result<Type> to return the type...
+
+- Add a setting in FunctionEvaluator to enable or disable type argument checking

--- a/src/CrossCutting.CodeGeneration/CodeGenerationProviders/AbstractBuilders.cs
+++ b/src/CrossCutting.CodeGeneration/CodeGenerationProviders/AbstractBuilders.cs
@@ -5,6 +5,7 @@ public class AbstractBuilders(IPipelineService pipelineService) : CrossCuttingCS
 {
     public override string Path => $"{Constants.Namespaces.UtilitiesParsers}/Builders";
 
+    protected override bool EnableBuilderInhericance => true;
     protected override bool EnableEntityInheritance => true;
     protected override bool IsAbstract => true;
 

--- a/src/CrossCutting.CodeGeneration/CodeGenerationProviders/AbstractNonGenericBuilders.cs
+++ b/src/CrossCutting.CodeGeneration/CodeGenerationProviders/AbstractNonGenericBuilders.cs
@@ -8,6 +8,7 @@ public class AbstractNonGenericBuilders(IPipelineService pipelineService) : Cros
     protected override bool AddNullChecks => false; // not needed for abstract builders, because each derived class will do its own validation
     protected override bool AddBackingFields => true; // backing fields are added when using null checks... so we need to add this explicitly
 
+    protected override bool EnableBuilderInhericance => true;
     protected override bool EnableEntityInheritance => true;
     protected override bool CreateAsObservable => true;
     protected override bool IsAbstract => true;

--- a/src/CrossCutting.CodeGeneration/CodeGenerationProviders/FunctionCallArguments/OverrideBuilders.cs
+++ b/src/CrossCutting.CodeGeneration/CodeGenerationProviders/FunctionCallArguments/OverrideBuilders.cs
@@ -1,4 +1,4 @@
-﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.FunctionCallArguments;
+﻿namespace CrossCutting.CodeGeneration.CodeGenerationProviders.FunctionCallArguments;
 
 [ExcludeFromCodeCoverage]
 public class OverrideBuilders(IPipelineService pipelineService) : CrossCuttingCSharpClassBase(pipelineService)

--- a/src/CrossCutting.CodeGeneration/CodeGenerationProviders/FunctionCallArguments/OverrideEntities.cs
+++ b/src/CrossCutting.CodeGeneration/CodeGenerationProviders/FunctionCallArguments/OverrideEntities.cs
@@ -1,4 +1,4 @@
-﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.FunctionCallArguments;
+﻿namespace CrossCutting.CodeGeneration.CodeGenerationProviders.FunctionCallArguments;
 
 [ExcludeFromCodeCoverage]
 public class OverrideEntities(IPipelineService pipelineService) : CrossCuttingCSharpClassBase(pipelineService)

--- a/src/CrossCutting.CodeGeneration/Models/IExpressionStringEvaluatorSettings.cs
+++ b/src/CrossCutting.CodeGeneration/Models/IExpressionStringEvaluatorSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace CrossCutting.CodeGeneration.Models;
+
+internal interface IExpressionStringEvaluatorSettings
+{
+    IFormatProvider FormatProvider { get; }
+    [DefaultValue(true)] bool ValidateArgumentTypes { get; }
+}

--- a/src/CrossCutting.CodeGeneration/Models/IFormattableStringParserSettings.cs
+++ b/src/CrossCutting.CodeGeneration/Models/IFormattableStringParserSettings.cs
@@ -3,6 +3,7 @@
 internal interface IFormattableStringParserSettings
 {
     IFormatProvider FormatProvider { get; }
+    [DefaultValue(true)] bool ValidateArgumentTypes { get; }
     [Required(AllowEmptyStrings = false)] string PlaceholderStart { get; }
     [Required(AllowEmptyStrings = false)] string PlaceholderEnd { get; }
     [DefaultValue(true)] bool EscapeBraces { get; }

--- a/src/CrossCutting.CodeGeneration/Models/IFunctionEvaluatorSettings.cs
+++ b/src/CrossCutting.CodeGeneration/Models/IFunctionEvaluatorSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace CrossCutting.CodeGeneration.Models;
+
+internal interface IFunctionEvaluatorSettings
+{
+    IFormatProvider FormatProvider { get; }
+    [DefaultValue(true)] bool ValidateArgumentTypes { get; }
+}

--- a/src/CrossCutting.CodeGeneration/Models/IPlaceholderSettings.cs
+++ b/src/CrossCutting.CodeGeneration/Models/IPlaceholderSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace CrossCutting.CodeGeneration.Models;
+
+internal interface IPlaceholderSettings
+{
+    IFormatProvider FormatProvider { get; }
+    [DefaultValue(true)] bool ValidateArgumentTypes { get; }
+}

--- a/src/CrossCutting.CodeGeneration/Program.cs
+++ b/src/CrossCutting.CodeGeneration/Program.cs
@@ -46,12 +46,33 @@ internal static class Program
         var tasks = instances
             .Select(x => engine.Generate(x, new MultipleStringContentBuilderEnvironment(), new CodeGenerationSettings(basePath, Path.Combine(x.Path, $"{x.GetType().Name}.template.generated.cs"))))
             .ToArray();
-        await Task.WhenAll(tasks);
+        var results = await Task.WhenAll(tasks);
+
+        var errors = results.Where(x => !x.IsSuccessful()).ToArray();
+        if (errors.Length > 0)
+        {
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+            Console.WriteLine("Errors:");
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
+            foreach (var error in errors)
+            {
+                WriteError(error);
+            }
+        }
 
         // Log output to console
         if (!string.IsNullOrEmpty(basePath))
         {
             Console.WriteLine($"Code generation completed, check the output in {basePath}");
+        }
+    }
+
+    private static void WriteError(Result error)
+    {
+        Console.WriteLine($"{error.Status} {error.ErrorMessage}");
+        foreach (var innerResult in error.InnerResults)
+        {
+            WriteError(innerResult);
         }
     }
 }

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/Current/ExpressionFrameworkTest.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/Current/ExpressionFrameworkTest.cs
@@ -3,7 +3,7 @@
 public sealed class ExpressionFrameworkTest
 {
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     [Fact]
     public void Can_Parse_ToUpperCaseExpression()

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/Current/ExpressionFrameworkTest.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/Current/ExpressionFrameworkTest.cs
@@ -2,6 +2,9 @@
 
 public sealed class ExpressionFrameworkTest
 {
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     [Fact]
     public void Can_Parse_ToUpperCaseExpression()
     {
@@ -11,7 +14,7 @@ public sealed class ExpressionFrameworkTest
         var expressionEvaluator = Substitute.For<IExpressionEvaluator>();
         expressionEvaluator.Evaluate(Arg.Any<string>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>()).Returns(x => Result.Success<object?>(x.ArgAt<string>(0)));
         var functionCall = new FunctionCallBuilder().WithName("ToUpperCase").AddArguments(new ConstantArgumentBuilder().WithValue("Hello world!")).Build();
-        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = sut.Parse(context);
@@ -30,7 +33,7 @@ public sealed class ExpressionFrameworkTest
         var expressionEvaluator = Substitute.For<IExpressionEvaluator>();
         expressionEvaluator.Evaluate(Arg.Any<string>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>()).Returns(x => Result.Success<object?>(x.ArgAt<string>(0)));
         var functionCall = new FunctionCallBuilder().WithName("ToUpperCase").AddArguments(new ConstantArgumentBuilder().WithValue("Hello world!")).Build();
-        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -48,7 +51,7 @@ public sealed class ExpressionFrameworkTest
         var expressionEvaluator = Substitute.For<IExpressionEvaluator>();
         expressionEvaluator.Evaluate(Arg.Any<string>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>()).Returns(x => Result.Success<object?>(x.ArgAt<string>(0)));
         var functionCall = new FunctionCallBuilder().WithName("ToUpperCase").AddArguments(new ConstantArgumentBuilder().WithValue("Hello world!")).Build();
-        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/HowItShouldBe/ExpressionFrameworkHowItShouldBeTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/HowItShouldBe/ExpressionFrameworkHowItShouldBeTests.cs
@@ -3,7 +3,7 @@
 public class ExpressionFrameworkHowItShouldBeTests
 {
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     [Fact]
     public void Can_Validate_ToUpperCaseExpression()

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/HowItShouldBe/ExpressionFrameworkHowItShouldBeTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/HowItShouldBe/ExpressionFrameworkHowItShouldBeTests.cs
@@ -2,6 +2,9 @@
 
 public class ExpressionFrameworkHowItShouldBeTests
 {
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     [Fact]
     public void Can_Validate_ToUpperCaseExpression()
     {
@@ -12,7 +15,7 @@ public class ExpressionFrameworkHowItShouldBeTests
         var functionCall = new ToUpperCaseFunctionCallBuilder()
             .WithExpression("Hello world!")
             .Build();
-        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -31,7 +34,7 @@ public class ExpressionFrameworkHowItShouldBeTests
         var functionCall = new ToUpperCaseFunctionCallBuilder()
             .WithExpression("Hello world!")
             .Build();
-        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -53,7 +56,7 @@ public class ExpressionFrameworkHowItShouldBeTests
             .WithExpression(Result.Success("Hello world!"))
             .WithCultureInfo(CultureInfo.InvariantCulture)
             .Build();
-        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = sut.EvaluateTyped(context);
@@ -155,7 +158,7 @@ public class ToUpperCaseFunction : ITypedFunction<string>, IValidatableFunction
     private static Func<Dictionary<string, Result>, Result<string>> OnSuccess(FunctionCallContext context)
     {
         // Note that if you provide a static Evaluate method without FunctionCallContext, then you can't use the function call context (format provider, expression evaluator etc.)
-        return results => Result.Success(Expression(results).ToUpper(CultureInfo(results, context?.FormatProvider.ToCultureInfo())));
+        return results => Result.Success(Expression(results).ToUpper(CultureInfo(results, context?.Settings.FormatProvider.ToCultureInfo())));
     }
 
     private static Result OnFailure(Result error)
@@ -257,7 +260,7 @@ public class ToUpperCaseFunctionCallContext : FunctionCallContext, IResultDictio
 {
     public Dictionary<string, Result> Results { get; }
 
-    public ToUpperCaseFunctionCallContext(FunctionCallContext context) : base(context?.FunctionCall ?? throw new ArgumentNullException(nameof(context)), context.FunctionEvaluator, context.ExpressionEvaluator, context.FormatProvider, context.Context)
+    public ToUpperCaseFunctionCallContext(FunctionCallContext context) : base(context?.FunctionCall ?? throw new ArgumentNullException(nameof(context)), context.FunctionEvaluator, context.ExpressionEvaluator, context.Settings, context.Context)
     {
         Results = new ResultDictionaryBuilder()
             // Note that you can use both GetArgumentValueResult<string> or GetArgumentStringValueResult.

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/New/ExpressionFrameworkNewTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/New/ExpressionFrameworkNewTests.cs
@@ -4,6 +4,9 @@ namespace CrossCutting.Utilities.Parsers.Tests.ExpressionFrameworkTests.New;
 
 public class ExpressionFrameworkNewTests
 {
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     [Fact]
     public void Can_Validate_ToLowerCaseExpression()
     {
@@ -14,7 +17,7 @@ public class ExpressionFrameworkNewTests
         var functionCall = new ToLowerCaseExpressionBuilder()
             .WithExpression(new TypedConstantExpressionBuilder<string>().WithValue("Hello world!"))
             .BuildFunctionCall();
-        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -34,7 +37,7 @@ public class ExpressionFrameworkNewTests
         var functionCall = new ToLowerCaseExpressionBuilder()
             .WithExpression(new TypedConstantExpressionBuilder<string>().WithValue("Hello world!"))
             .BuildFunctionCall();
-        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(functionCall, functionEvaluator, expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/New/ExpressionFrameworkNewTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionFrameworkTests/New/ExpressionFrameworkNewTests.cs
@@ -5,7 +5,7 @@ namespace CrossCutting.Utilities.Parsers.Tests.ExpressionFrameworkTests.New;
 public class ExpressionFrameworkNewTests
 {
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     [Fact]
     public void Can_Validate_ToLowerCaseExpression()

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionStringEvaluatorTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionStringEvaluatorTests.cs
@@ -22,6 +22,10 @@ public class ExpressionStringEvaluatorTests : IDisposable
         _scope = _provider.CreateScope();
     }
 
+
+    protected static ExpressionStringEvaluatorSettings CreateSettings()
+        => new ExpressionStringEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     public class Evaluate : ExpressionStringEvaluatorTests
     {
         [Fact]
@@ -31,7 +35,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = string.Empty;
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -45,7 +49,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = default(string);
 
             // Act
-            var result = CreateSut().Evaluate(input!, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input!, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -59,7 +63,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -73,7 +77,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "string that does not begin with =";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -87,7 +91,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=1+1";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -102,7 +106,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             _variable.Evaluate(Arg.Any<string>(), Arg.Any<object?>()).Returns(x => x.ArgAt<string>(0) == "myvariable" ? Result.Success<object?>("MyVariableValue") : Result.Continue<object?>());
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -116,7 +120,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=1+error";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.NotSupported);
@@ -130,7 +134,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=@\"Hello {Name}!\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = CreateSut().Evaluate(input, CreateSettings(), _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -144,7 +148,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=@\"Hello {Name}!\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -158,7 +162,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=@\"Hello {Kaboom}!\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = CreateSut().Evaluate(input, CreateSettings(), _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
@@ -172,7 +176,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello {Name}!\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -186,7 +190,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello | {Name}!\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -200,7 +204,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello & {Name}!\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -214,7 +218,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"a\" == \"b\" == \"c\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -228,7 +232,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=MYFUNCTION()";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -242,7 +246,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=toupper(@\"Hello {Name}!\")";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = CreateSut().Evaluate(input, CreateSettings(), _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -256,7 +260,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=error()";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
@@ -270,7 +274,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "some string that does not start with = sign";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -284,7 +288,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"some string that starts with = sign but does not contain any formattable string, function or mathematical expression\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -298,7 +302,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello {Name}!\" | ToUpper(context)";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -312,7 +316,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello \" & \"Name!\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -326,7 +330,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello \" & @\"{Name}!\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = CreateSut().Evaluate(input, CreateSettings(), _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -340,7 +344,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello \" & \"{Name}!\" | ToUpper(context)";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -354,7 +358,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello\" == \"Hello\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -368,7 +372,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=1 == 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -382,7 +386,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null == \"Hello\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -396,7 +400,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello\" == null";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -410,7 +414,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null == null";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -424,7 +428,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=error() == \"Hello\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
@@ -437,7 +441,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello\" == error()";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
@@ -450,7 +454,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello\" != \"Hello\"";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -464,7 +468,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null > 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -478,7 +482,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=2 > null";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -492,7 +496,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=3 > 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -506,7 +510,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"hello\" > 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -520,7 +524,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null >= 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -534,7 +538,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=2 >= null";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -548,7 +552,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=3 >= 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -562,7 +566,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"hello\" >= 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -576,7 +580,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null < 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -590,7 +594,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=2 < null";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -604,7 +608,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=3 < 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -618,7 +622,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"hello\" < 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -632,7 +636,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null <= 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -646,7 +650,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=2 <= null";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -660,7 +664,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=3 <= 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -674,7 +678,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"hello\" <= 2";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -688,7 +692,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=somefunction(\uE002)";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -702,7 +706,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=()";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.NotFound);
@@ -721,7 +725,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=MYFUNCTION()";
 
             // Act
-            var result = scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -735,7 +739,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "\'=error()";
 
             // Act
-            var result = CreateSut().Evaluate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Evaluate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -754,10 +758,10 @@ public class ExpressionStringEvaluatorTests : IDisposable
                 .BuildServiceProvider(true);
             using var scope = provider.CreateScope();
 
-            var parser = scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
+            var sut = scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
 
             // Act
-            var result = parser.Evaluate(input, CultureInfo.InvariantCulture, scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = sut.Evaluate(input, CreateSettings(), scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -774,7 +778,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = string.Empty;
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -787,7 +791,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = default(string);
 
             // Act
-            var result = CreateSut().Validate(input!, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input!, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -801,7 +805,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -814,7 +818,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "string that does not begin with =";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -827,7 +831,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=1+1";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -841,7 +845,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             _variable.Validate(Arg.Any<string>(), Arg.Any<object?>()).Returns(x => x.ArgAt<string>(0) == "myvariable" ? Result.Success<Type>(typeof(string)) : Result.Continue<Type>());
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -854,7 +858,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=1+error";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.NotSupported);
@@ -868,7 +872,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=@\"Hello {Name}!\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = CreateSut().Validate(input, CreateSettings(), _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -881,7 +885,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=@\"Hello {Name}!\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -894,7 +898,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=@\"Hello {Kaboom}!\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = CreateSut().Validate(input, CreateSettings(), _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -909,7 +913,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello {Name}!\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -922,7 +926,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello | {Name}!\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -935,7 +939,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello & {Name}!\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -948,7 +952,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"a\" == \"b\" == \"c\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -961,7 +965,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=MYFUNCTION()";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -974,7 +978,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=TOUPPER(@\"Hello {Name}!\")";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = CreateSut().Validate(input, CreateSettings(), _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -987,7 +991,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "some string that does not start with = sign";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1000,7 +1004,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"some string that starts with = sign but does not contain any formattable string, function or mathematical expression\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1013,7 +1017,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello {Name}!\" | ToUpper(\"bla\")";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.NoContent);
@@ -1026,7 +1030,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello \" & \"Name!\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.NoContent);
@@ -1039,7 +1043,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello \" & @\"{Name}!\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture, _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
+            var result = CreateSut().Validate(input, CreateSettings(), _scope.ServiceProvider.GetRequiredService<IFormattableStringParser>());
 
             // Assert
             result.Status.Should().Be(ResultStatus.NoContent);
@@ -1052,7 +1056,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello \" & \"{Name}!\" | ToUpper(\"bla\")";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.NoContent);
@@ -1065,7 +1069,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello\" == \"Hello\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1078,7 +1082,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=1 == 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1091,7 +1095,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null == \"Hello\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1104,7 +1108,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello\" == null";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1117,7 +1121,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null == null";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1130,7 +1134,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=\"Hello\" != \"Hello\"";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1143,7 +1147,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null > 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1156,7 +1160,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=2 > null";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1169,7 +1173,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=3 > 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1182,7 +1186,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null >= 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1195,7 +1199,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=2 >= null";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1208,7 +1212,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=3 >= 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1221,7 +1225,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null < 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1234,7 +1238,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=2 < null";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1247,7 +1251,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=3 < 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1260,7 +1264,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=null <= 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1273,7 +1277,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=2 <= null";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1286,7 +1290,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=3 <= 2";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1299,7 +1303,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=somefunction(\uE002)";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -1313,7 +1317,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=()";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.NotFound);
@@ -1332,7 +1336,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "=MYFUNCTION()";
 
             // Act
-            var result = scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>().Validate(input, CultureInfo.InvariantCulture);
+            var result = scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -1346,7 +1350,7 @@ public class ExpressionStringEvaluatorTests : IDisposable
             var input = "\'=error()";
 
             // Act
-            var result = CreateSut().Validate(input, CultureInfo.InvariantCulture);
+            var result = CreateSut().Validate(input, CreateSettings());
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -1357,12 +1361,12 @@ public class ExpressionStringEvaluatorTests : IDisposable
 
     private sealed class MyPlaceholderProcessor : IPlaceholder
     {
-        public Result<GenericFormattableString> Evaluate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result<GenericFormattableString> Evaluate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
                 ? Result.Success(new GenericFormattableString(ReplacedValue))
                 : Result.Error<GenericFormattableString>($"Unsupported placeholder name: {value}");
 
-        public Result Validate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result Validate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
                 ? Result.Success()
                 : Result.Error($"Unsupported placeholder name: {value}");

--- a/src/CrossCutting.Utilities.Parsers.Tests/ExpressionStringEvaluatorTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/ExpressionStringEvaluatorTests.cs
@@ -22,9 +22,8 @@ public class ExpressionStringEvaluatorTests : IDisposable
         _scope = _provider.CreateScope();
     }
 
-
     protected static ExpressionStringEvaluatorSettings CreateSettings()
-        => new ExpressionStringEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new ExpressionStringEvaluatorSettingsBuilder().Build();
 
     public class Evaluate : ExpressionStringEvaluatorTests
     {

--- a/src/CrossCutting.Utilities.Parsers.Tests/Extensions/ExpressionStringEvaluatorExtensionsTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/Extensions/ExpressionStringEvaluatorExtensionsTests.cs
@@ -6,65 +6,65 @@ public class ExpressionStringEvaluatorExtensionsTests
     private IFormattableStringParser FormattableStringParserMock { get; } = Substitute.For<IFormattableStringParser>();
     private const string Input = "Some input";
     private object Context { get; } = new object();
-    private IFormatProvider FormatProvider { get; } = CultureInfo.InvariantCulture;
+    private ExpressionStringEvaluatorSettings Settings { get; } = new ExpressionStringEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
 
     [Fact]
     public void Evaluate_Without_Context_And_FormattableStringParser_Gets_Processed_Correctly()
     {
         // Act
-        _ = SutMock.Evaluate(Input, FormatProvider);
+        _ = SutMock.Evaluate(Input, Settings);
 
         // Assert
-        SutMock.Received().Evaluate(Input, FormatProvider, null, null);
+        SutMock.Received().Evaluate(Input, Settings, null, null);
     }
 
     [Fact]
     public void Evaluate_Without_Context_Gets_Processed_Correctly()
     {
         // Act
-        _ = SutMock.Evaluate(Input, FormatProvider, FormattableStringParserMock);
+        _ = SutMock.Evaluate(Input, Settings, FormattableStringParserMock);
 
         // Assert
-        SutMock.Received().Evaluate(Input, FormatProvider, null, FormattableStringParserMock);
+        SutMock.Received().Evaluate(Input, Settings, null, FormattableStringParserMock);
     }
 
     [Fact]
     public void Evaluate_Without_FormattableStringParser_Gets_Processed_Correctly()
     {
         // Act
-        _ = SutMock.Evaluate(Input, FormatProvider, Context);
+        _ = SutMock.Evaluate(Input, Settings, Context);
 
         // Assert
-        SutMock.Received().Evaluate(Input, FormatProvider, Context, null);
+        SutMock.Received().Evaluate(Input, Settings, Context, null);
     }
 
     [Fact]
     public void Validate_Without_Context_And_FormattableStringParser_Gets_Processed_Correctly()
     {
         // Act
-        _ = SutMock.Validate(Input, FormatProvider);
+        _ = SutMock.Validate(Input, Settings);
 
         // Assert
-        SutMock.Received().Validate(Input, FormatProvider, null, null);
+        SutMock.Received().Validate(Input, Settings, null, null);
     }
 
     [Fact]
     public void Validate_Without_Context_Gets_Processed_Correctly()
     {
         // Act
-        _ = SutMock.Validate(Input, FormatProvider, FormattableStringParserMock);
+        _ = SutMock.Validate(Input, Settings, FormattableStringParserMock);
 
         // Assert
-        SutMock.Received().Validate(Input, FormatProvider, null, FormattableStringParserMock);
+        SutMock.Received().Validate(Input, Settings, null, FormattableStringParserMock);
     }
 
     [Fact]
     public void Validate_Without_FormattableStringParser_Gets_Processed_Correctly()
     {
         // Act
-        _ = SutMock.Validate(Input, FormatProvider, Context);
+        _ = SutMock.Validate(Input, Settings, Context);
 
         // Assert
-        SutMock.Received().Validate(Input, FormatProvider, Context, null);
+        SutMock.Received().Validate(Input, Settings, Context, null);
     }
 }

--- a/src/CrossCutting.Utilities.Parsers.Tests/Extensions/ExpressionStringEvaluatorExtensionsTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/Extensions/ExpressionStringEvaluatorExtensionsTests.cs
@@ -6,7 +6,7 @@ public class ExpressionStringEvaluatorExtensionsTests
     private IFormattableStringParser FormattableStringParserMock { get; } = Substitute.For<IFormattableStringParser>();
     private const string Input = "Some input";
     private object Context { get; } = new object();
-    private ExpressionStringEvaluatorSettings Settings { get; } = new ExpressionStringEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+    private ExpressionStringEvaluatorSettings Settings { get; } = new ExpressionStringEvaluatorSettingsBuilder().Build();
 
     [Fact]
     public void Evaluate_Without_Context_And_FormattableStringParser_Gets_Processed_Correctly()

--- a/src/CrossCutting.Utilities.Parsers.Tests/Extensions/FunctionParserExtensionsTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/Extensions/FunctionParserExtensionsTests.cs
@@ -15,7 +15,7 @@ public class FunctionParserExtensionsTests
         _ = SutMock.Parse(Input, FormatProvider);
 
         // Assert
-        SutMock.Received().Parse(Input, FormatProvider, null, null);
+        SutMock.Received().Parse(Input, Arg.Is<FunctionParserSettings>(x => x.FormatProvider == FormatProvider && x.FormattableStringParser == null), Arg.Any<object?>());
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public class FunctionParserExtensionsTests
         _ = SutMock.Parse(Input, FormatProvider, FormattableStringParserMock);
 
         // Assert
-        SutMock.Received().Parse(Input, FormatProvider, FormattableStringParserMock, null);
+        SutMock.Received().Parse(Input, Arg.Is<FunctionParserSettings>(x => x.FormatProvider == FormatProvider && x.FormattableStringParser == FormattableStringParserMock), Arg.Any<object?>());
     }
 
     [Fact]
@@ -35,6 +35,6 @@ public class FunctionParserExtensionsTests
         _ = SutMock.Parse(Input, FormatProvider, Context);
 
         // Assert
-        SutMock.Received().Parse(Input, FormatProvider, null, Context);
+        SutMock.Received().Parse(Input, Arg.Is<FunctionParserSettings>(x => x.FormatProvider == FormatProvider && x.FormattableStringParser ==  null), Context);
     }
 }

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -796,7 +796,7 @@ public sealed class FormattableStringParserTests : IDisposable
 
     private sealed class MyPlaceholderProcessor : IPlaceholder
     {
-        public Result<GenericFormattableString> Evaluate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result<GenericFormattableString> Evaluate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser)
         {
             return value switch
             {
@@ -808,7 +808,7 @@ public sealed class FormattableStringParserTests : IDisposable
             };
         }
 
-        public Result Validate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result Validate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser)
         {
             return value switch
             {

--- a/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FormattableStringParserTests.cs
@@ -315,7 +315,7 @@ public sealed class FormattableStringParserTests : IDisposable
         // Arrange
         var input = "public class Bla {{ /* implementation goes here with {Name} */ }}";
         var settings = new FormattableStringParserSettingsBuilder()
-            .WithFormatProvider(CultureInfo.InvariantCulture)
+            
             .WithPlaceholderStart("{")
             .WithPlaceholderEnd("}")
             .Build();
@@ -335,7 +335,7 @@ public sealed class FormattableStringParserTests : IDisposable
         // Arrange
         var input = "public class Bla { /* implementation goes here with {{Name}} */ }";
         var settings = new FormattableStringParserSettingsBuilder()
-            .WithFormatProvider(CultureInfo.InvariantCulture)
+            
             .WithPlaceholderStart("{{")
             .WithPlaceholderEnd("}}")
             .Build();
@@ -371,7 +371,7 @@ public sealed class FormattableStringParserTests : IDisposable
         // Arrange
         var input = "public class Bla {{ /* implementation goes here with <Name> */ }}";
         var settings = new FormattableStringParserSettingsBuilder()
-            .WithFormatProvider(CultureInfo.InvariantCulture)
+            
             .WithPlaceholderStart("<")
             .WithPlaceholderEnd(">")
             .WithEscapeBraces(false)
@@ -648,7 +648,7 @@ public sealed class FormattableStringParserTests : IDisposable
         var input = "Hello {{Name}}!";
         var sut = CreateSut();
         var settings = new FormattableStringParserSettingsBuilder()
-            .WithFormatProvider(CultureInfo.InvariantCulture)
+            
             .WithPlaceholderStart("{{")
             .WithPlaceholderEnd("}}")
             .Build();
@@ -676,7 +676,7 @@ public sealed class FormattableStringParserTests : IDisposable
         var input = $"Hello {start}Name{end}!";
         var sut = CreateSut();
         var settings = new FormattableStringParserSettingsBuilder()
-            .WithFormatProvider(CultureInfo.InvariantCulture)
+            
             .WithPlaceholderStart(start)
             .WithPlaceholderEnd(end)
             .Build();

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/ConstantArgumentTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/ConstantArgumentTests.cs
@@ -2,12 +2,15 @@
 
 public class ConstantArgumentTests
 {
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     [Fact]
     public void EvaluateTyped_Returns_Correct_Result()
     {
         // Arrange
         var sut = new ConstantArgument<string>("Hello world!");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.EvaluateTyped(context);
@@ -22,7 +25,7 @@ public class ConstantArgumentTests
     {
         // Arrange
         var sut = new ConstantArgument<string>("Hello world!");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -37,7 +40,7 @@ public class ConstantArgumentTests
     {
         // Arrange
         var sut = new ConstantArgument("Hello world!");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -52,7 +55,7 @@ public class ConstantArgumentTests
     {
         // Arrange
         var sut = new ConstantArgument<string>("Hello world!");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -67,7 +70,7 @@ public class ConstantArgumentTests
     {
         // Arrange
         var sut = new ConstantArgument("Hello world!");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -82,7 +85,6 @@ public class ConstantArgumentTests
     {
         // Arrange
         var sut = new ConstantArgument<string>("Hello world!");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
 
         // Act
         var result = sut.ToBuilder();
@@ -97,7 +99,6 @@ public class ConstantArgumentTests
     {
         // Arrange
         var sut = new ConstantArgument<string>("Hello world!");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
 
         // Act
         var result = sut.ToTypedBuilder();
@@ -112,7 +113,6 @@ public class ConstantArgumentTests
     {
         // Arrange
         var sut = new ConstantArgument<string>("Hello world!");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
 
         // Act
         var result = sut.Value;

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/ConstantArgumentTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/ConstantArgumentTests.cs
@@ -3,7 +3,7 @@
 public class ConstantArgumentTests
 {
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     [Fact]
     public void EvaluateTyped_Returns_Correct_Result()

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/ConstantResultArgumentTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/ConstantResultArgumentTests.cs
@@ -2,12 +2,15 @@
 
 public class ConstantResultArgumentTests
 {
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     [Fact]
     public void EvaluateTyped_Returns_Correct_Result()
     {
         // Arrange
         var sut = new ConstantResultArgument<string>(Result.Success("Hello world!"));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.EvaluateTyped(context);
@@ -22,7 +25,7 @@ public class ConstantResultArgumentTests
     {
         // Arrange
         var sut = new ConstantResultArgument<string>(Result.Success("Hello world!"));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -37,7 +40,7 @@ public class ConstantResultArgumentTests
     {
         // Arrange
         var sut = new ConstantResultArgument(Result.Success<object?>("Hello world!"));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -52,7 +55,7 @@ public class ConstantResultArgumentTests
     {
         // Arrange
         var sut = new ConstantResultArgument<string>(Result.Success("Hello world!"));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -67,7 +70,7 @@ public class ConstantResultArgumentTests
     {
         // Arrange
         var sut = new ConstantResultArgument(Result.Success<object?>("Hello world!"));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -82,7 +85,6 @@ public class ConstantResultArgumentTests
     {
         // Arrange
         var sut = new ConstantResultArgument<string>(Result.Success("Hello world!"));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
 
         // Act
         var result = sut.ToBuilder();
@@ -97,7 +99,6 @@ public class ConstantResultArgumentTests
     {
         // Arrange
         var sut = new ConstantResultArgument<string>(Result.Success("Hello world!"));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
 
         // Act
         var result = sut.ToTypedBuilder();
@@ -112,7 +113,6 @@ public class ConstantResultArgumentTests
     {
         // Arrange
         var sut = new ConstantResultArgument<string>(Result.Success("Hello world!"));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
 
         // Act
         var result = sut.Result;

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/ConstantResultArgumentTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/ConstantResultArgumentTests.cs
@@ -3,7 +3,7 @@
 public class ConstantResultArgumentTests
 {
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     [Fact]
     public void EvaluateTyped_Returns_Correct_Result()

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/DelegateArgumentTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/DelegateArgumentTests.cs
@@ -3,7 +3,7 @@
 public class DelegateArgumentTests
 {
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     [Fact]
     public void EvaluateTyped_Returns_Correct_Result()

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/DelegateArgumentTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/DelegateArgumentTests.cs
@@ -2,12 +2,15 @@
 
 public class DelegateArgumentTests
 {
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     [Fact]
     public void EvaluateTyped_Returns_Correct_Result()
     {
         // Arrange
         var sut = new DelegateArgument<string>(() => "Hello world!", null);
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.EvaluateTyped(context);
@@ -22,7 +25,7 @@ public class DelegateArgumentTests
     {
         // Arrange
         var sut = new DelegateArgument<string>(() => "Hello world!", null);
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -37,7 +40,7 @@ public class DelegateArgumentTests
     {
         // Arrange
         var sut = new DelegateArgument(() => "Hello world!", null);
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -52,7 +55,7 @@ public class DelegateArgumentTests
     {
         // Arrange
         var sut = new DelegateArgument<string>(() => "Hello world!", () => typeof(string));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -67,7 +70,7 @@ public class DelegateArgumentTests
     {
         // Arrange
         var sut = new DelegateArgument(() => "Hello world!", () => typeof(string));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/DelegateResultArgumentTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/DelegateResultArgumentTests.cs
@@ -3,7 +3,7 @@
 public class DelegateResultArgumentTests
 {
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     [Fact]
     public void EvaluateTyped_Returns_Correct_Result()

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/DelegateResultArgumentTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallArguments/DelegateResultArgumentTests.cs
@@ -2,12 +2,15 @@
 
 public class DelegateResultArgumentTests
 {
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     [Fact]
     public void EvaluateTyped_Returns_Correct_Result()
     {
         // Arrange
         var sut = new DelegateResultArgument<string>(() => Result.Success("Hello world!"), null);
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.EvaluateTyped(context);
@@ -22,7 +25,7 @@ public class DelegateResultArgumentTests
     {
         // Arrange
         var sut = new DelegateResultArgument<string>(() => Result.Success("Hello world!"), null);
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -37,7 +40,7 @@ public class DelegateResultArgumentTests
     {
         // Arrange
         var sut = new DelegateResultArgument(() => Result.Success<object?>("Hello world!"), null);
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Evaluate(context);
@@ -52,7 +55,7 @@ public class DelegateResultArgumentTests
     {
         // Arrange
         var sut = new DelegateResultArgument<string>(() => Result.Success("Hello world!"), () => Result.Success(typeof(string)));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);
@@ -67,7 +70,7 @@ public class DelegateResultArgumentTests
     {
         // Arrange
         var sut = new DelegateResultArgument(() => Result.Success<object?>("Hello world!"), () => Result.Success(typeof(string)));
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null);
 
         // Act
         var result = sut.Validate(context);

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallContextTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallContextTests.cs
@@ -9,7 +9,7 @@ public class FunctionCallContextTests : IDisposable
     private bool disposedValue;
 
     protected static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     public FunctionCallContextTests()
     {

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallContextTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallContextTests.cs
@@ -8,11 +8,14 @@ public class FunctionCallContextTests : IDisposable
     private readonly IServiceScope _scope;
     private bool disposedValue;
 
+    protected static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     public FunctionCallContextTests()
     {
         _functionEvaluatorMock
             //<FunctionParseResult, IExpressionParser, object?>((result, _, _)
-            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<object?>())
+            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<FunctionEvaluatorSettings>(), Arg.Any<object?>())
             .Returns(x => x.ArgAt<FunctionCall>(0).Name switch
             {
                 "MyNestedFunction" => Result.Success<object?>("Evaluated result"),
@@ -42,7 +45,7 @@ public class FunctionCallContextTests : IDisposable
         public void Throws_On_Null_FunctionCall()
         {
             // Act & Assert
-            this.Invoking(_ => new FunctionCallContext(null!, Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), Substitute.For<IFormatProvider>(), null))
+            this.Invoking(_ => new FunctionCallContext(null!, Substitute.For<IFunctionEvaluator>(), Substitute.For<IExpressionEvaluator>(), CreateSettings(), null))
                 .Should().Throw<ArgumentNullException>();
         }
 
@@ -50,7 +53,7 @@ public class FunctionCallContextTests : IDisposable
         public void Throws_On_Null_FunctionEvaluator()
         {
             // Act & Assert
-            this.Invoking(_ => new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), null!, Substitute.For<IExpressionEvaluator>(), Substitute.For<IFormatProvider>(), null))
+            this.Invoking(_ => new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), null!, Substitute.For<IExpressionEvaluator>(), CreateSettings(), null))
                 .Should().Throw<ArgumentNullException>();
         }
 
@@ -58,7 +61,7 @@ public class FunctionCallContextTests : IDisposable
         public void Throws_On_Null_ExpressionEvaluator()
         {
             // Act & Assert
-            this.Invoking(_ => new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), null!, Substitute.For<IFormatProvider>(), null))
+            this.Invoking(_ => new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), Substitute.For<IFunctionEvaluator>(), null!, CreateSettings(), null))
                 .Should().Throw<ArgumentNullException>();
         }
 
@@ -331,19 +334,19 @@ public class FunctionCallContextTests : IDisposable
     protected FunctionCallContext CreateFunctionCallContextWithoutArguments()
         => new FunctionCallContext(new FunctionCallBuilder()
             .WithName("Test")
-            .Build(), _functionEvaluatorMock, _expressionEvaluatorMock, CultureInfo.InvariantCulture, null);
+            .Build(), _functionEvaluatorMock, _expressionEvaluatorMock, CreateSettings(), null);
 
     protected FunctionCallContext CreateFunctionCallContextWithConstantArgument()
         => new FunctionCallContext(new FunctionCallBuilder()
             .WithName("Test")
             .AddArguments(new ConstantArgumentBuilder().WithValue("some value"))
-            .Build(), _functionEvaluatorMock, _expressionEvaluatorMock, CultureInfo.InvariantCulture, null);
+            .Build(), _functionEvaluatorMock, _expressionEvaluatorMock, CreateSettings(), null);
 
     protected FunctionCallContext CreateFunctionCallContextWithFunctionArgument(string functionName)
         => new FunctionCallContext(new FunctionCallBuilder()
             .WithName("Test")
             .AddArguments(new FunctionArgumentBuilder().WithFunction(new FunctionCallBuilder().WithName(functionName)))
-            .Build(), _functionEvaluatorMock, _expressionEvaluatorMock, CultureInfo.InvariantCulture, null);
+            .Build(), _functionEvaluatorMock, _expressionEvaluatorMock, CreateSettings(), null);
 
     protected virtual void Dispose(bool disposing)
     {

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallTests.cs
@@ -8,7 +8,7 @@ public sealed class FunctionCallTests : IDisposable
     private readonly IServiceScope _scope;
 
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     public FunctionCallTests()
     {

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionCallTests.cs
@@ -7,10 +7,13 @@ public sealed class FunctionCallTests : IDisposable
     private readonly ServiceProvider _provider;
     private readonly IServiceScope _scope;
 
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+
     public FunctionCallTests()
     {
         _functionEvaluatorMock
-            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<object?>())
+            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<FunctionEvaluatorSettings>(), Arg.Any<object?>())
             .Returns(x => x.ArgAt<FunctionCall>(0).Name switch
             {
                 "MyNestedFunction" => Result.Success<object?>("Evaluated result"),
@@ -37,7 +40,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentValueResult(1, "SomeName", context);
@@ -52,7 +55,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentValueResult(0, "SomeName", context);
@@ -67,7 +70,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithDelegateArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentValueResult(0, "SomeName", context);
@@ -82,7 +85,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentValueResult(0, "SomeName", context, (object)"ignored");
@@ -97,7 +100,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("MyNestedFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentValueResult(0, "SomeName", context);
@@ -112,7 +115,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithoutArguments();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentValueResult(0, "SomeName", context, (object)"some value");
@@ -127,7 +130,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentStringValueResult(1, "SomeName", context);
@@ -142,7 +145,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("NumericFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentStringValueResult(0, "SomeName", context);
@@ -157,7 +160,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentStringValueResult(0, "SomeName", context);
@@ -172,7 +175,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithoutArguments();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentStringValueResult(0, "SomeName", context, "default value");
@@ -187,7 +190,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt32ValueResult(1, "SomeName", context);
@@ -202,7 +205,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("NumericFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt32ValueResult(0, "SomeName", context);
@@ -217,7 +220,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt32ValueResult(0, "SomeName", context);
@@ -232,7 +235,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("UnknownExpressionString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt32ValueResult(0, "SomeName", context);
@@ -247,7 +250,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt32ValueResult(0, "SomeName", context);
@@ -262,7 +265,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("NumericFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt32ValueResult(0, "SomeName", context);
@@ -277,7 +280,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithoutArguments();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt32ValueResult(0, "SomeName", context, 13);
@@ -292,7 +295,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt64ValueResult(1, "SomeName", context);
@@ -307,7 +310,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("LongFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt64ValueResult(0, "SomeName", context);
@@ -322,7 +325,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt64ValueResult(0, "SomeName", context);
@@ -337,7 +340,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("UnknownExpressionString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt64ValueResult(0, "SomeName", context);
@@ -352,7 +355,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt64ValueResult(0, "SomeName", context);
@@ -367,7 +370,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("LongFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt64ValueResult(0, "SomeName", context);
@@ -382,7 +385,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithoutArguments();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentInt64ValueResult(0, "SomeName", context, 13L);
@@ -397,7 +400,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDecimalValueResult(1, "SomeName", context);
@@ -412,7 +415,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DecimalFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDecimalValueResult(0, "SomeName", context);
@@ -427,7 +430,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDecimalValueResult(0, "SomeName", context);
@@ -442,7 +445,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("UnknownExpressionString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDecimalValueResult(0, "SomeName", context);
@@ -457,7 +460,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDecimalValueResult(0, "SomeName", context);
@@ -472,7 +475,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DecimalFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDecimalValueResult(0, "SomeName", context);
@@ -487,7 +490,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithoutArguments();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDecimalValueResult(0, "SomeName", context, 13.5M);
@@ -502,7 +505,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentBooleanValueResult(1, "SomeName", context);
@@ -517,7 +520,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("BooleanFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentBooleanValueResult(0, "SomeName", context);
@@ -532,7 +535,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentBooleanValueResult(0, "SomeName", context);
@@ -547,7 +550,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("UnknownExpressionString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentBooleanValueResult(0, "SomeName", context);
@@ -562,7 +565,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentBooleanValueResult(0, "SomeName", context);
@@ -577,7 +580,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("BooleanFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentBooleanValueResult(0, "SomeName", context);
@@ -592,7 +595,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithoutArguments();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentBooleanValueResult(0, "SomeName", context, true);
@@ -607,7 +610,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithConstantArgument();
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDateTimeValueResult(1, "SomeName", context);
@@ -622,7 +625,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", context);
@@ -637,7 +640,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("NumericFunction");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", context);
@@ -652,7 +655,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("UnknownExpressionString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", context);
@@ -667,7 +670,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("NumericFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", context);
@@ -682,7 +685,7 @@ public sealed class FunctionCallTests : IDisposable
     {
         // Arrange
         var argument = CreateFunctionCallWithFunctionArgument("DateTimeFunctionAsString");
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", context);
@@ -698,7 +701,7 @@ public sealed class FunctionCallTests : IDisposable
         // Arrange
         var argument = CreateFunctionCallWithoutArguments();
         var dt = DateTime.Now;
-        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CultureInfo.InvariantCulture, null);
+        var context = new FunctionCallContext(new FunctionCallBuilder().WithName("Dummy").Build(), _functionEvaluatorMock, _expressionEvaluator, CreateSettings(), null);
 
         // Act
         var result = argument.GetArgumentDateTimeValueResult(0, "SomeName", context, dt);

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionEvaluatorTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionEvaluatorTests.cs
@@ -33,7 +33,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Evaluate(functionCall!);
+        var result = sut.Evaluate(functionCall!, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -48,7 +48,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Evaluate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Evaluate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -63,7 +63,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Evaluate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Evaluate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -78,7 +78,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Evaluate(functionCall, default(object?));
+        var result = sut.Evaluate(functionCall, CreateSettings(), default(object?));
 
         // Assert
         result.Status.Should().Be(ResultStatus.Error);
@@ -96,7 +96,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Evaluate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Evaluate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -113,7 +113,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Evaluate(functionCall);
+        var result = sut.Evaluate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -128,7 +128,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Evaluate(functionCall, default(object?));
+        var result = sut.Evaluate(functionCall, CreateSettings(), default(object?));
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -144,7 +144,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.EvaluateTyped<string>(functionCall!);
+        var result = sut.EvaluateTyped<string>(functionCall!, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -159,7 +159,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.EvaluateTyped<int>(functionCall);
+        var result = sut.EvaluateTyped<int>(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -174,7 +174,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.EvaluateTyped<string>(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.EvaluateTyped<string>(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -189,7 +189,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.EvaluateTyped<string>(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.EvaluateTyped<string>(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -204,7 +204,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.EvaluateTyped<string>(functionCall, default(object?));
+        var result = sut.EvaluateTyped<string>(functionCall, CreateSettings(), default(object?));
 
         // Assert
         result.Status.Should().Be(ResultStatus.Error);
@@ -219,7 +219,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.EvaluateTyped<string>(functionCall);
+        var result = sut.EvaluateTyped<string>(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -234,7 +234,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall!);
+        var result = sut.Validate(functionCall!, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -249,7 +249,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -267,7 +267,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -285,7 +285,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -300,7 +300,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -315,7 +315,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -332,7 +332,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -346,7 +346,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall, default(object?));
+        var result = sut.Validate(functionCall, CreateSettings(), default(object?));
 
         // Assert
         result.Status.Should().Be(ResultStatus.Error);
@@ -361,7 +361,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -376,7 +376,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -394,7 +394,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -412,7 +412,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -429,7 +429,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -453,7 +453,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -477,7 +477,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -498,7 +498,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -522,7 +522,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
@@ -547,7 +547,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var functionCall = new FunctionCallBuilder().WithName("MyFunction").Build();
 
         // Act
-        var result = sut.Validate(functionCall);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Arrange
         result.Status.Should().Be(ResultStatus.Error);
@@ -565,7 +565,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         var sut = CreateSut();
 
         // Act
-        var result = sut.Validate(functionCall, CultureInfo.InvariantCulture);
+        var result = sut.Validate(functionCall, CreateSettings());
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -578,7 +578,11 @@ public sealed class FunctionEvaluatorTests : IDisposable
         _provider.Dispose();
     }
 
-    private IFunctionEvaluator CreateSut() => _scope.ServiceProvider.GetRequiredService<IFunctionEvaluator>();
+    private IFunctionEvaluator CreateSut()
+        => _scope.ServiceProvider.GetRequiredService<IFunctionEvaluator>();
+
+    private static FunctionEvaluatorSettings CreateSettings()
+        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
 
     private sealed class ErrorFunction : IValidatableFunction
     {

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionEvaluatorTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionEvaluatorTests.cs
@@ -449,7 +449,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
             .Build();
         var sut = CreateSut();
         var settings = new FunctionEvaluatorSettingsBuilder()
-            .WithFormatProvider(CultureInfo.InvariantCulture)
+            
             .WithValidateArgumentTypes(false)
             .Build();
 
@@ -603,7 +603,7 @@ public sealed class FunctionEvaluatorTests : IDisposable
         => _scope.ServiceProvider.GetRequiredService<IFunctionEvaluator>();
 
     private static FunctionEvaluatorSettings CreateSettings()
-        => new FunctionEvaluatorSettingsBuilder().WithFormatProvider(CultureInfo.InvariantCulture).Build();
+        => new FunctionEvaluatorSettingsBuilder().Build();
 
     private sealed class ErrorFunction : IValidatableFunction
     {

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionEvaluatorTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionEvaluatorTests.cs
@@ -440,6 +440,27 @@ public sealed class FunctionEvaluatorTests : IDisposable
     }
 
     [Fact]
+    public void Validate_Returns_Result_From_Validation_When_Overload_ArgumentCount_Is_Correct_And_Argument_Is_Of_Wrong_Type_But_ValidateArgumentTypes_Setting_Is_False()
+    {
+        // Arrange
+        var functionCall = new FunctionCallBuilder()
+            .WithName("Overload")
+            .AddArguments(new ConstantArgumentBuilder().WithValue(13))
+            .Build();
+        var sut = CreateSut();
+        var settings = new FunctionEvaluatorSettingsBuilder()
+            .WithFormatProvider(CultureInfo.InvariantCulture)
+            .WithValidateArgumentTypes(false)
+            .Build();
+
+        // Act
+        var result = sut.Validate(functionCall, settings);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+    }
+
+    [Fact]
     public void Validate_Returns_Result_From_Validation_When_Overload_ArgumentCount_Is_Correct_But_Argument_Has_Non_Succesful_Result_Constant()
     {
         // Arrange

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
@@ -414,12 +414,12 @@ public sealed class FunctionParserTests : IDisposable
 
     private sealed class MyPlaceholderProcessor : IPlaceholder
     {
-        public Result<GenericFormattableString> Evaluate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result<GenericFormattableString> Evaluate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
                 ? Result.Success<GenericFormattableString>(ReplacedValue)
                 : Result.Error<GenericFormattableString>($"Unsupported placeholder name: {value}");
 
-        public Result Validate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+        public Result Validate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser)
             => value == "Name"
                 ? Result.Success()
                 : Result.Error($"Unsupported placeholder name: {value}");

--- a/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
+++ b/src/CrossCutting.Utilities.Parsers.Tests/FunctionParserTests.cs
@@ -403,7 +403,7 @@ public sealed class FunctionParserTests : IDisposable
 
     private sealed class ErrorArgumentProcessor : IFunctionParserArgumentProcessor
     {
-        public Result<FunctionCallArgument> Process(string argument, IReadOnlyCollection<FunctionCall> functionCalls, IFormatProvider formatProvider, IFormattableStringParser? formattableStringParser, object? context)
+        public Result<FunctionCallArgument> Process(string argument, IReadOnlyCollection<FunctionCall> functionCalls, FunctionParserSettings settings, object? context)
             => Result.Error<FunctionCallArgument>("Kaboom");
     }
 

--- a/src/CrossCutting.Utilities.Parsers/Builders/CoreBuilders.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/CoreBuilders.template.generated.cs
@@ -10,9 +10,87 @@
 #nullable enable
 namespace CrossCutting.Utilities.Parsers.Builders
 {
+    public partial class ExpressionStringEvaluatorSettingsBuilder : System.ComponentModel.INotifyPropertyChanged
+    {
+        private System.IFormatProvider _formatProvider;
+
+        private bool _validateArgumentTypes;
+
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+        public System.IFormatProvider FormatProvider
+        {
+            get
+            {
+                return _formatProvider;
+            }
+            set
+            {
+                bool hasChanged = !System.Collections.Generic.EqualityComparer<System.IFormatProvider>.Default.Equals(_formatProvider!, value!);
+                _formatProvider = value ?? throw new System.ArgumentNullException(nameof(value));
+                if (hasChanged) HandlePropertyChanged(nameof(FormatProvider));
+            }
+        }
+
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool ValidateArgumentTypes
+        {
+            get
+            {
+                return _validateArgumentTypes;
+            }
+            set
+            {
+                bool hasChanged = !System.Collections.Generic.EqualityComparer<System.Boolean>.Default.Equals(_validateArgumentTypes, value);
+                _validateArgumentTypes = value;
+                if (hasChanged) HandlePropertyChanged(nameof(ValidateArgumentTypes));
+            }
+        }
+
+        public ExpressionStringEvaluatorSettingsBuilder(CrossCutting.Utilities.Parsers.ExpressionStringEvaluatorSettings source)
+        {
+            if (source is null) throw new System.ArgumentNullException(nameof(source));
+            _formatProvider = source.FormatProvider;
+            _validateArgumentTypes = source.ValidateArgumentTypes;
+        }
+
+        public ExpressionStringEvaluatorSettingsBuilder()
+        {
+            _formatProvider = System.Globalization.CultureInfo.InvariantCulture!;
+            _validateArgumentTypes = true;
+            SetDefaultValues();
+        }
+
+        public CrossCutting.Utilities.Parsers.ExpressionStringEvaluatorSettings Build()
+        {
+            return new CrossCutting.Utilities.Parsers.ExpressionStringEvaluatorSettings(FormatProvider, ValidateArgumentTypes);
+        }
+
+        partial void SetDefaultValues();
+
+        public CrossCutting.Utilities.Parsers.Builders.ExpressionStringEvaluatorSettingsBuilder WithFormatProvider(System.IFormatProvider formatProvider)
+        {
+            if (formatProvider is null) throw new System.ArgumentNullException(nameof(formatProvider));
+            FormatProvider = formatProvider;
+            return this;
+        }
+
+        public CrossCutting.Utilities.Parsers.Builders.ExpressionStringEvaluatorSettingsBuilder WithValidateArgumentTypes(bool validateArgumentTypes = true)
+        {
+            ValidateArgumentTypes = validateArgumentTypes;
+            return this;
+        }
+
+        protected void HandlePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+        }
+    }
     public partial class FormattableStringParserSettingsBuilder : System.ComponentModel.INotifyPropertyChanged
     {
         private System.IFormatProvider _formatProvider;
+
+        private bool _validateArgumentTypes;
 
         private string _placeholderStart;
 
@@ -35,6 +113,21 @@ namespace CrossCutting.Utilities.Parsers.Builders
                 bool hasChanged = !System.Collections.Generic.EqualityComparer<System.IFormatProvider>.Default.Equals(_formatProvider!, value!);
                 _formatProvider = value ?? throw new System.ArgumentNullException(nameof(value));
                 if (hasChanged) HandlePropertyChanged(nameof(FormatProvider));
+            }
+        }
+
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool ValidateArgumentTypes
+        {
+            get
+            {
+                return _validateArgumentTypes;
+            }
+            set
+            {
+                bool hasChanged = !System.Collections.Generic.EqualityComparer<System.Boolean>.Default.Equals(_validateArgumentTypes, value);
+                _validateArgumentTypes = value;
+                if (hasChanged) HandlePropertyChanged(nameof(ValidateArgumentTypes));
             }
         }
 
@@ -102,6 +195,7 @@ namespace CrossCutting.Utilities.Parsers.Builders
         {
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _formatProvider = source.FormatProvider;
+            _validateArgumentTypes = source.ValidateArgumentTypes;
             _placeholderStart = source.PlaceholderStart;
             _placeholderEnd = source.PlaceholderEnd;
             _escapeBraces = source.EscapeBraces;
@@ -111,6 +205,7 @@ namespace CrossCutting.Utilities.Parsers.Builders
         public FormattableStringParserSettingsBuilder()
         {
             _formatProvider = System.Globalization.CultureInfo.InvariantCulture!;
+            _validateArgumentTypes = true;
             _placeholderStart = string.Empty;
             _placeholderEnd = string.Empty;
             _escapeBraces = true;
@@ -120,7 +215,7 @@ namespace CrossCutting.Utilities.Parsers.Builders
 
         public CrossCutting.Utilities.Parsers.FormattableStringParserSettings Build()
         {
-            return new CrossCutting.Utilities.Parsers.FormattableStringParserSettings(FormatProvider, PlaceholderStart, PlaceholderEnd, EscapeBraces, MaximumRecursion);
+            return new CrossCutting.Utilities.Parsers.FormattableStringParserSettings(FormatProvider, ValidateArgumentTypes, PlaceholderStart, PlaceholderEnd, EscapeBraces, MaximumRecursion);
         }
 
         partial void SetDefaultValues();
@@ -129,6 +224,12 @@ namespace CrossCutting.Utilities.Parsers.Builders
         {
             if (formatProvider is null) throw new System.ArgumentNullException(nameof(formatProvider));
             FormatProvider = formatProvider;
+            return this;
+        }
+
+        public CrossCutting.Utilities.Parsers.Builders.FormattableStringParserSettingsBuilder WithValidateArgumentTypes(bool validateArgumentTypes = true)
+        {
+            ValidateArgumentTypes = validateArgumentTypes;
             return this;
         }
 
@@ -687,6 +788,158 @@ namespace CrossCutting.Utilities.Parsers.Builders
         {
             if (description is null) throw new System.ArgumentNullException(nameof(description));
             Description = description;
+            return this;
+        }
+
+        protected void HandlePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+        }
+    }
+    public partial class FunctionEvaluatorSettingsBuilder : System.ComponentModel.INotifyPropertyChanged
+    {
+        private System.IFormatProvider _formatProvider;
+
+        private bool _validateArgumentTypes;
+
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+        public System.IFormatProvider FormatProvider
+        {
+            get
+            {
+                return _formatProvider;
+            }
+            set
+            {
+                bool hasChanged = !System.Collections.Generic.EqualityComparer<System.IFormatProvider>.Default.Equals(_formatProvider!, value!);
+                _formatProvider = value ?? throw new System.ArgumentNullException(nameof(value));
+                if (hasChanged) HandlePropertyChanged(nameof(FormatProvider));
+            }
+        }
+
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool ValidateArgumentTypes
+        {
+            get
+            {
+                return _validateArgumentTypes;
+            }
+            set
+            {
+                bool hasChanged = !System.Collections.Generic.EqualityComparer<System.Boolean>.Default.Equals(_validateArgumentTypes, value);
+                _validateArgumentTypes = value;
+                if (hasChanged) HandlePropertyChanged(nameof(ValidateArgumentTypes));
+            }
+        }
+
+        public FunctionEvaluatorSettingsBuilder(CrossCutting.Utilities.Parsers.FunctionEvaluatorSettings source)
+        {
+            if (source is null) throw new System.ArgumentNullException(nameof(source));
+            _formatProvider = source.FormatProvider;
+            _validateArgumentTypes = source.ValidateArgumentTypes;
+        }
+
+        public FunctionEvaluatorSettingsBuilder()
+        {
+            _formatProvider = System.Globalization.CultureInfo.InvariantCulture!;
+            _validateArgumentTypes = true;
+            SetDefaultValues();
+        }
+
+        public CrossCutting.Utilities.Parsers.FunctionEvaluatorSettings Build()
+        {
+            return new CrossCutting.Utilities.Parsers.FunctionEvaluatorSettings(FormatProvider, ValidateArgumentTypes);
+        }
+
+        partial void SetDefaultValues();
+
+        public CrossCutting.Utilities.Parsers.Builders.FunctionEvaluatorSettingsBuilder WithFormatProvider(System.IFormatProvider formatProvider)
+        {
+            if (formatProvider is null) throw new System.ArgumentNullException(nameof(formatProvider));
+            FormatProvider = formatProvider;
+            return this;
+        }
+
+        public CrossCutting.Utilities.Parsers.Builders.FunctionEvaluatorSettingsBuilder WithValidateArgumentTypes(bool validateArgumentTypes = true)
+        {
+            ValidateArgumentTypes = validateArgumentTypes;
+            return this;
+        }
+
+        protected void HandlePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+        }
+    }
+    public partial class PlaceholderSettingsBuilder : System.ComponentModel.INotifyPropertyChanged
+    {
+        private System.IFormatProvider _formatProvider;
+
+        private bool _validateArgumentTypes;
+
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+        public System.IFormatProvider FormatProvider
+        {
+            get
+            {
+                return _formatProvider;
+            }
+            set
+            {
+                bool hasChanged = !System.Collections.Generic.EqualityComparer<System.IFormatProvider>.Default.Equals(_formatProvider!, value!);
+                _formatProvider = value ?? throw new System.ArgumentNullException(nameof(value));
+                if (hasChanged) HandlePropertyChanged(nameof(FormatProvider));
+            }
+        }
+
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool ValidateArgumentTypes
+        {
+            get
+            {
+                return _validateArgumentTypes;
+            }
+            set
+            {
+                bool hasChanged = !System.Collections.Generic.EqualityComparer<System.Boolean>.Default.Equals(_validateArgumentTypes, value);
+                _validateArgumentTypes = value;
+                if (hasChanged) HandlePropertyChanged(nameof(ValidateArgumentTypes));
+            }
+        }
+
+        public PlaceholderSettingsBuilder(CrossCutting.Utilities.Parsers.PlaceholderSettings source)
+        {
+            if (source is null) throw new System.ArgumentNullException(nameof(source));
+            _formatProvider = source.FormatProvider;
+            _validateArgumentTypes = source.ValidateArgumentTypes;
+        }
+
+        public PlaceholderSettingsBuilder()
+        {
+            _formatProvider = System.Globalization.CultureInfo.InvariantCulture!;
+            _validateArgumentTypes = true;
+            SetDefaultValues();
+        }
+
+        public CrossCutting.Utilities.Parsers.PlaceholderSettings Build()
+        {
+            return new CrossCutting.Utilities.Parsers.PlaceholderSettings(FormatProvider, ValidateArgumentTypes);
+        }
+
+        partial void SetDefaultValues();
+
+        public CrossCutting.Utilities.Parsers.Builders.PlaceholderSettingsBuilder WithFormatProvider(System.IFormatProvider formatProvider)
+        {
+            if (formatProvider is null) throw new System.ArgumentNullException(nameof(formatProvider));
+            FormatProvider = formatProvider;
+            return this;
+        }
+
+        public CrossCutting.Utilities.Parsers.Builders.PlaceholderSettingsBuilder WithValidateArgumentTypes(bool validateArgumentTypes = true)
+        {
+            ValidateArgumentTypes = validateArgumentTypes;
             return this;
         }
 

--- a/src/CrossCutting.Utilities.Parsers/Builders/ExpressionStringEvaluatorSettingsBuilder.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/ExpressionStringEvaluatorSettingsBuilder.cs
@@ -1,0 +1,9 @@
+﻿namespace CrossCutting.Utilities.Parsers.Builders;
+
+public partial class ExpressionStringEvaluatorSettingsBuilder
+{
+    partial void SetDefaultValues()
+    {
+        FormatProvider = CultureInfo.InvariantCulture;
+    }
+}

--- a/src/CrossCutting.Utilities.Parsers/Builders/FunctionEvaluatorSettingsBuilder.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/FunctionEvaluatorSettingsBuilder.cs
@@ -1,0 +1,9 @@
+﻿namespace CrossCutting.Utilities.Parsers.Builders;
+
+public partial class FunctionEvaluatorSettingsBuilder
+{
+    partial void SetDefaultValues()
+    {
+        FormatProvider = CultureInfo.InvariantCulture;
+    }
+}

--- a/src/CrossCutting.Utilities.Parsers/Builders/PlaceholderSettingsBuilder.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/PlaceholderSettingsBuilder.cs
@@ -1,9 +1,0 @@
-﻿namespace CrossCutting.Utilities.Parsers.Builders;
-
-public partial class PlaceholderSettingsBuilder
-{
-    partial void SetDefaultValues()
-    {
-        FormatProvider = CultureInfo.InvariantCulture;
-    }
-}

--- a/src/CrossCutting.Utilities.Parsers/Builders/PlaceholderSettingsBuilder.cs
+++ b/src/CrossCutting.Utilities.Parsers/Builders/PlaceholderSettingsBuilder.cs
@@ -1,0 +1,9 @@
+﻿namespace CrossCutting.Utilities.Parsers.Builders;
+
+public partial class PlaceholderSettingsBuilder
+{
+    partial void SetDefaultValues()
+    {
+        FormatProvider = CultureInfo.InvariantCulture;
+    }
+}

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IExpressionString.cs
@@ -2,7 +2,7 @@
 
 public interface IExpressionString
 {
-    Result<Type> Validate(ExpressionStringEvaluatorState state);
+    Result<Type> Validate(ExpressionStringEvaluatorContext context);
 
-    Result<object?> Evaluate(ExpressionStringEvaluatorState state);
+    Result<object?> Evaluate(ExpressionStringEvaluatorContext context);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IExpressionStringEvaluator.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IExpressionStringEvaluator.cs
@@ -2,7 +2,7 @@
 
 public interface IExpressionStringEvaluator
 {
-    Result<Type> Validate(string expressionString, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser);
+    Result<Type> Validate(string expressionString, ExpressionStringEvaluatorSettings settings, object? context, IFormattableStringParser? formattableStringParser);
 
-    Result<object?> Evaluate(string expressionString, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser);
+    Result<object?> Evaluate(string expressionString, ExpressionStringEvaluatorSettings settings, object? context, IFormattableStringParser? formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionEvaluator.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionEvaluator.cs
@@ -2,9 +2,9 @@
 
 public interface IFunctionEvaluator
 {
-    Result<Type> Validate(FunctionCall functionCall, IFormatProvider formatProvider, object? context);
+    Result<Type> Validate(FunctionCall functionCall, FunctionEvaluatorSettings settings, object? context);
 
-    Result<object?> Evaluate(FunctionCall functionCall, IFormatProvider formatProvider, object? context);
+    Result<object?> Evaluate(FunctionCall functionCall, FunctionEvaluatorSettings settings, object? context);
 
-    Result<T> EvaluateTyped<T>(FunctionCall functionCall, IFormatProvider formatProvider, object? context);
+    Result<T> EvaluateTyped<T>(FunctionCall functionCall, FunctionEvaluatorSettings settings, object? context);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionParser.cs
@@ -2,5 +2,5 @@
 
 public interface IFunctionParser
 {
-    Result<FunctionCall> Parse(string function, IFormatProvider formatProvider, IFormattableStringParser? formattableStringParser, object? context);
+    Result<FunctionCall> Parse(string function, FunctionParserSettings settings, object? context);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionParserArgumentProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IFunctionParserArgumentProcessor.cs
@@ -2,5 +2,5 @@
 
 public interface IFunctionParserArgumentProcessor
 {
-    Result<FunctionCallArgument> Process(string argument, IReadOnlyCollection<FunctionCall> functionCalls, IFormatProvider formatProvider, IFormattableStringParser? formattableStringParser, object? context);
+    Result<FunctionCallArgument> Process(string argument, IReadOnlyCollection<FunctionCall> functionCalls, FunctionParserSettings settings, object? context);
 }

--- a/src/CrossCutting.Utilities.Parsers/Contracts/IPlaceholder.cs
+++ b/src/CrossCutting.Utilities.Parsers/Contracts/IPlaceholder.cs
@@ -3,7 +3,7 @@
 public interface IPlaceholder
 {
     // Note that the return type is always FormattableString
-    Result Validate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser);
+    Result Validate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser);
 
-    Result<GenericFormattableString> Evaluate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser);
+    Result<GenericFormattableString> Evaluate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser);
 }

--- a/src/CrossCutting.Utilities.Parsers/CoreEntities.template.generated.cs
+++ b/src/CrossCutting.Utilities.Parsers/CoreEntities.template.generated.cs
@@ -10,9 +10,40 @@
 #nullable enable
 namespace CrossCutting.Utilities.Parsers
 {
+    public partial record ExpressionStringEvaluatorSettings
+    {
+        public System.IFormatProvider FormatProvider
+        {
+            get;
+        }
+
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool ValidateArgumentTypes
+        {
+            get;
+        }
+
+        public ExpressionStringEvaluatorSettings(System.IFormatProvider formatProvider, bool validateArgumentTypes)
+        {
+            this.FormatProvider = formatProvider;
+            this.ValidateArgumentTypes = validateArgumentTypes;
+            System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
+        }
+
+        public CrossCutting.Utilities.Parsers.Builders.ExpressionStringEvaluatorSettingsBuilder ToBuilder()
+        {
+            return new CrossCutting.Utilities.Parsers.Builders.ExpressionStringEvaluatorSettingsBuilder(this);
+        }
+    }
     public partial record FormattableStringParserSettings
     {
         public System.IFormatProvider FormatProvider
+        {
+            get;
+        }
+
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool ValidateArgumentTypes
         {
             get;
         }
@@ -41,9 +72,10 @@ namespace CrossCutting.Utilities.Parsers
             get;
         }
 
-        public FormattableStringParserSettings(System.IFormatProvider formatProvider, string placeholderStart, string placeholderEnd, bool escapeBraces, int maximumRecursion)
+        public FormattableStringParserSettings(System.IFormatProvider formatProvider, bool validateArgumentTypes, string placeholderStart, string placeholderEnd, bool escapeBraces, int maximumRecursion)
         {
             this.FormatProvider = formatProvider;
+            this.ValidateArgumentTypes = validateArgumentTypes;
             this.PlaceholderStart = placeholderStart;
             this.PlaceholderEnd = placeholderEnd;
             this.EscapeBraces = escapeBraces;
@@ -213,6 +245,56 @@ namespace CrossCutting.Utilities.Parsers
         public CrossCutting.Utilities.Parsers.Builders.FunctionDescriptorResultBuilder ToBuilder()
         {
             return new CrossCutting.Utilities.Parsers.Builders.FunctionDescriptorResultBuilder(this);
+        }
+    }
+    public partial record FunctionEvaluatorSettings
+    {
+        public System.IFormatProvider FormatProvider
+        {
+            get;
+        }
+
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool ValidateArgumentTypes
+        {
+            get;
+        }
+
+        public FunctionEvaluatorSettings(System.IFormatProvider formatProvider, bool validateArgumentTypes)
+        {
+            this.FormatProvider = formatProvider;
+            this.ValidateArgumentTypes = validateArgumentTypes;
+            System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
+        }
+
+        public CrossCutting.Utilities.Parsers.Builders.FunctionEvaluatorSettingsBuilder ToBuilder()
+        {
+            return new CrossCutting.Utilities.Parsers.Builders.FunctionEvaluatorSettingsBuilder(this);
+        }
+    }
+    public partial record PlaceholderSettings
+    {
+        public System.IFormatProvider FormatProvider
+        {
+            get;
+        }
+
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool ValidateArgumentTypes
+        {
+            get;
+        }
+
+        public PlaceholderSettings(System.IFormatProvider formatProvider, bool validateArgumentTypes)
+        {
+            this.FormatProvider = formatProvider;
+            this.ValidateArgumentTypes = validateArgumentTypes;
+            System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
+        }
+
+        public CrossCutting.Utilities.Parsers.Builders.PlaceholderSettingsBuilder ToBuilder()
+        {
+            return new CrossCutting.Utilities.Parsers.Builders.PlaceholderSettingsBuilder(this);
         }
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
+++ b/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Parsers</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>8.0.2</Version>
-    <PackageVersion>8.0.2</PackageVersion>
+    <Version>9.0.0</Version>
+    <PackageVersion>9.0.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluator.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluator.cs
@@ -20,14 +20,14 @@ public class ExpressionStringEvaluator : IExpressionStringEvaluator
         _expressionStrings = expressionStrings;
     }
 
-    public Result<object?> Evaluate(string expressionString, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
+    public Result<object?> Evaluate(string expressionString, ExpressionStringEvaluatorSettings settings, object? context, IFormattableStringParser? formattableStringParser)
     {
         if (expressionString is null)
         {
             return Result.Invalid<object?>("Expression string is required");
         }
 
-        var state = new ExpressionStringEvaluatorContext(expressionString, formatProvider, context, this, formattableStringParser);
+        var state = new ExpressionStringEvaluatorContext(expressionString, settings, context, this, formattableStringParser);
 
         return _expressionStrings
             .Select(x => x.Evaluate(state))
@@ -35,14 +35,14 @@ public class ExpressionStringEvaluator : IExpressionStringEvaluator
                 ?? EvaluateSimpleExpression(state);
     }
 
-    public Result<Type> Validate(string expressionString, IFormatProvider formatProvider, object? context, IFormattableStringParser? formattableStringParser)
+    public Result<Type> Validate(string expressionString, ExpressionStringEvaluatorSettings settings, object? context, IFormattableStringParser? formattableStringParser)
     {
         if (expressionString is null)
         {
             return Result.Invalid<Type>("Expression string is required");
         }
 
-        var state = new ExpressionStringEvaluatorContext(expressionString, formatProvider, context, this, formattableStringParser);
+        var state = new ExpressionStringEvaluatorContext(expressionString, settings, context, this, formattableStringParser);
 
         return _expressionStrings
             .Select(x => x.Validate(state))
@@ -53,24 +53,24 @@ public class ExpressionStringEvaluator : IExpressionStringEvaluator
     private Result<object?> EvaluateSimpleExpression(ExpressionStringEvaluatorContext context)
     {
         // =something else, we can try function
-        var functionResult = _functionParser.Parse(context.Input.Substring(1), new FunctionParserSettings(context.FormatProvider, context.FormattableStringParser), context.Context);
+        var functionResult = _functionParser.Parse(context.Input.Substring(1), new FunctionParserSettings(context.Settings.FormatProvider, context.FormattableStringParser), context.Context);
         if (!functionResult.IsSuccessful())
         {
             return Result.FromExistingResult<object?>(functionResult);
         }
 
-        return _functionEvaluator.Evaluate(functionResult.Value!, context.FormatProvider, context.Context);
+        return _functionEvaluator.Evaluate(functionResult.Value!, new FunctionEvaluatorSettings(context.Settings.FormatProvider, context.Settings.ValidateArgumentTypes), context.Context);
     }
 
     private Result<Type> ValidateSimpleExpression(ExpressionStringEvaluatorContext context)
     {
         // =something else, we can try function
-        var functionResult = _functionParser.Parse(context.Input.Substring(1), new FunctionParserSettings(context.FormatProvider, context.FormattableStringParser), context.Context);
+        var functionResult = _functionParser.Parse(context.Input.Substring(1), new FunctionParserSettings(context.Settings.FormatProvider, context.FormattableStringParser), context.Context);
         if (!functionResult.IsSuccessful())
         {
             return Result.FromExistingResult<Type>(functionResult);
         }
 
-        return _functionEvaluator.Validate(functionResult.Value!, context.FormatProvider, context.Context);
+        return _functionEvaluator.Validate(functionResult.Value!, new FunctionEvaluatorSettings(context.Settings.FormatProvider, context.Settings.ValidateArgumentTypes), context.Context);
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluator.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluator.cs
@@ -53,7 +53,7 @@ public class ExpressionStringEvaluator : IExpressionStringEvaluator
     private Result<object?> EvaluateSimpleExpression(ExpressionStringEvaluatorContext context)
     {
         // =something else, we can try function
-        var functionResult = _functionParser.Parse(context.Input.Substring(1), context.FormatProvider, context.FormattableStringParser, context.Context);
+        var functionResult = _functionParser.Parse(context.Input.Substring(1), new FunctionParserSettings(context.FormatProvider, context.FormattableStringParser), context.Context);
         if (!functionResult.IsSuccessful())
         {
             return Result.FromExistingResult<object?>(functionResult);
@@ -65,7 +65,7 @@ public class ExpressionStringEvaluator : IExpressionStringEvaluator
     private Result<Type> ValidateSimpleExpression(ExpressionStringEvaluatorContext context)
     {
         // =something else, we can try function
-        var functionResult = _functionParser.Parse(context.Input.Substring(1), context.FormatProvider, context.FormattableStringParser, context.Context);
+        var functionResult = _functionParser.Parse(context.Input.Substring(1), new FunctionParserSettings(context.FormatProvider, context.FormattableStringParser), context.Context);
         if (!functionResult.IsSuccessful())
         {
             return Result.FromExistingResult<Type>(functionResult);

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluator.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluator.cs
@@ -27,7 +27,7 @@ public class ExpressionStringEvaluator : IExpressionStringEvaluator
             return Result.Invalid<object?>("Expression string is required");
         }
 
-        var state = new ExpressionStringEvaluatorState(expressionString, formatProvider, context, this, formattableStringParser);
+        var state = new ExpressionStringEvaluatorContext(expressionString, formatProvider, context, this, formattableStringParser);
 
         return _expressionStrings
             .Select(x => x.Evaluate(state))
@@ -42,7 +42,7 @@ public class ExpressionStringEvaluator : IExpressionStringEvaluator
             return Result.Invalid<Type>("Expression string is required");
         }
 
-        var state = new ExpressionStringEvaluatorState(expressionString, formatProvider, context, this, formattableStringParser);
+        var state = new ExpressionStringEvaluatorContext(expressionString, formatProvider, context, this, formattableStringParser);
 
         return _expressionStrings
             .Select(x => x.Validate(state))
@@ -50,27 +50,27 @@ public class ExpressionStringEvaluator : IExpressionStringEvaluator
                 ?? ValidateSimpleExpression(state);
     }
 
-    private Result<object?> EvaluateSimpleExpression(ExpressionStringEvaluatorState state)
+    private Result<object?> EvaluateSimpleExpression(ExpressionStringEvaluatorContext context)
     {
         // =something else, we can try function
-        var functionResult = _functionParser.Parse(state.Input.Substring(1), state.FormatProvider, state.FormattableStringParser, state.Context);
+        var functionResult = _functionParser.Parse(context.Input.Substring(1), context.FormatProvider, context.FormattableStringParser, context.Context);
         if (!functionResult.IsSuccessful())
         {
             return Result.FromExistingResult<object?>(functionResult);
         }
 
-        return _functionEvaluator.Evaluate(functionResult.Value!, state.FormatProvider, state.Context);
+        return _functionEvaluator.Evaluate(functionResult.Value!, context.FormatProvider, context.Context);
     }
 
-    private Result<Type> ValidateSimpleExpression(ExpressionStringEvaluatorState state)
+    private Result<Type> ValidateSimpleExpression(ExpressionStringEvaluatorContext context)
     {
         // =something else, we can try function
-        var functionResult = _functionParser.Parse(state.Input.Substring(1), state.FormatProvider, state.FormattableStringParser, state.Context);
+        var functionResult = _functionParser.Parse(context.Input.Substring(1), context.FormatProvider, context.FormattableStringParser, context.Context);
         if (!functionResult.IsSuccessful())
         {
             return Result.FromExistingResult<Type>(functionResult);
         }
 
-        return _functionEvaluator.Validate(functionResult.Value!, state.FormatProvider, state.Context);
+        return _functionEvaluator.Validate(functionResult.Value!, context.FormatProvider, context.Context);
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluatorContext.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluatorContext.cs
@@ -3,24 +3,24 @@
 public class ExpressionStringEvaluatorContext
 {
     public string Input { get; }
-    public IFormatProvider FormatProvider { get; }
+    public ExpressionStringEvaluatorSettings Settings { get; }
     public object? Context { get; }
     public IExpressionStringEvaluator Parser { get; }
     public IFormattableStringParser? FormattableStringParser { get; }
 
     public ExpressionStringEvaluatorContext(
         string input,
-        IFormatProvider formatProvider,
+        ExpressionStringEvaluatorSettings settings,
         object? context,
         IExpressionStringEvaluator parser,
         IFormattableStringParser? formattableStringParser)
     {
         ArgumentGuard.IsNotNull(input, nameof(input));
-        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+        ArgumentGuard.IsNotNull(settings, nameof(settings));
         ArgumentGuard.IsNotNull(parser, nameof(parser));
 
         Input = input;
-        FormatProvider = formatProvider;
+        Settings = settings;
         Context = context;
         Parser = parser;
         FormattableStringParser = formattableStringParser;

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluatorContext.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStringEvaluatorContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace CrossCutting.Utilities.Parsers;
 
-public class ExpressionStringEvaluatorState
+public class ExpressionStringEvaluatorContext
 {
     public string Input { get; }
     public IFormatProvider FormatProvider { get; }
@@ -8,7 +8,7 @@ public class ExpressionStringEvaluatorState
     public IExpressionStringEvaluator Parser { get; }
     public IFormattableStringParser? FormattableStringParser { get; }
 
-    public ExpressionStringEvaluatorState(
+    public ExpressionStringEvaluatorContext(
         string input,
         IFormatProvider formatProvider,
         object? context,

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/BaseProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/BaseProcessor.cs
@@ -35,5 +35,5 @@ internal static class BaseProcessor
     }
 
     internal static Func<string[], Result<Type>> Parse(ExpressionStringEvaluatorContext context)
-        => split => Result.Aggregate(split.Select(item => context.Parser.Validate($"={item}", context.FormatProvider, context.Context, context.FormattableStringParser)), Result.NoContent<Type>(), validationResults => Result.Invalid<Type>("Validation failed, see inner results for details", validationResults));
+        => split => Result.Aggregate(split.Select(item => context.Parser.Validate($"={item}", context.Settings, context.Context, context.FormattableStringParser)), Result.NoContent<Type>(), validationResults => Result.Invalid<Type>("Validation failed, see inner results for details", validationResults));
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/BaseProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/BaseProcessor.cs
@@ -18,22 +18,6 @@ internal static class BaseProcessor
         return validDelegate(split);
     }
 
-    internal static Result SplitDelimited(ExpressionStringEvaluatorContext context, char splitDelimiter, Func<string[], Result> validDelegate)
-    {
-        if (context.Input.IndexOf(splitDelimiter) == -1)
-        {
-            return Result.Continue();
-        }
-
-        var split = context.Input.Substring(1).SplitDelimited(splitDelimiter, '\"', true, true);
-        if (split.Length == 1)
-        {
-            return Result.Continue();
-        }
-
-        return validDelegate(split);
-    }
-
     internal static Func<string[], Result<Type>> Parse(ExpressionStringEvaluatorContext context)
         => split => Result.Aggregate(split.Select(item => context.Parser.Validate($"={item}", context.Settings, context.Context, context.FormattableStringParser)), Result.NoContent<Type>(), validationResults => Result.Invalid<Type>("Validation failed, see inner results for details", validationResults));
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/BaseProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/BaseProcessor.cs
@@ -2,14 +2,14 @@
 
 internal static class BaseProcessor
 {
-    internal static Result<T> SplitDelimited<T>(ExpressionStringEvaluatorState state, char splitDelimiter, Func<string[], Result<T>> validDelegate)
+    internal static Result<T> SplitDelimited<T>(ExpressionStringEvaluatorContext context, char splitDelimiter, Func<string[], Result<T>> validDelegate)
     {
-        if (state.Input.IndexOf(splitDelimiter) == -1)
+        if (context.Input.IndexOf(splitDelimiter) == -1)
         {
             return Result.Continue<T>();
         }
 
-        var split = state.Input.Substring(1).SplitDelimited(splitDelimiter, '\"', true, true);
+        var split = context.Input.Substring(1).SplitDelimited(splitDelimiter, '\"', true, true);
         if (split.Length == 1)
         {
             return Result.Continue<T>();
@@ -18,14 +18,14 @@ internal static class BaseProcessor
         return validDelegate(split);
     }
 
-    internal static Result SplitDelimited(ExpressionStringEvaluatorState state, char splitDelimiter, Func<string[], Result> validDelegate)
+    internal static Result SplitDelimited(ExpressionStringEvaluatorContext context, char splitDelimiter, Func<string[], Result> validDelegate)
     {
-        if (state.Input.IndexOf(splitDelimiter) == -1)
+        if (context.Input.IndexOf(splitDelimiter) == -1)
         {
             return Result.Continue();
         }
 
-        var split = state.Input.Substring(1).SplitDelimited(splitDelimiter, '\"', true, true);
+        var split = context.Input.Substring(1).SplitDelimited(splitDelimiter, '\"', true, true);
         if (split.Length == 1)
         {
             return Result.Continue();
@@ -34,6 +34,6 @@ internal static class BaseProcessor
         return validDelegate(split);
     }
 
-    internal static Func<string[], Result<Type>> Parse(ExpressionStringEvaluatorState state)
-        => split => Result.Aggregate(split.Select(item => state.Parser.Validate($"={item}", state.FormatProvider, state.Context, state.FormattableStringParser)), Result.NoContent<Type>(), validationResults => Result.Invalid<Type>("Validation failed, see inner results for details", validationResults));
+    internal static Func<string[], Result<Type>> Parse(ExpressionStringEvaluatorContext context)
+        => split => Result.Aggregate(split.Select(item => context.Parser.Validate($"={item}", context.FormatProvider, context.Context, context.FormattableStringParser)), Result.NoContent<Type>(), validationResults => Result.Invalid<Type>("Validation failed, see inner results for details", validationResults));
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/ConcatenateExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/ConcatenateExpressionString.cs
@@ -11,12 +11,12 @@ public class ConcatenateExpressionString : IExpressionString
             var builder = new StringBuilder();
             foreach (var item in split)
             {
-                var result = context.Parser.Evaluate($"={item}", context.FormatProvider, context.Context, context.FormattableStringParser);
+                var result = context.Parser.Evaluate($"={item}", context.Settings, context.Context, context.FormattableStringParser);
                 if (!result.IsSuccessful())
                 {
                     return result;
                 }
-                builder.Append(result.Value.ToString(context.FormatProvider));
+                builder.Append(result.Value.ToString(context.Settings.FormatProvider));
             }
 
             return Result.Success<object?>(builder.ToString());

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/ConcatenateExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/ConcatenateExpressionString.cs
@@ -2,36 +2,36 @@
 
 public class ConcatenateExpressionString : IExpressionString
 {
-    public Result<object?> Evaluate(ExpressionStringEvaluatorState state)
+    public Result<object?> Evaluate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        return BaseProcessor.SplitDelimited(state, '&', split =>
+        return BaseProcessor.SplitDelimited(context, '&', split =>
         {
             var builder = new StringBuilder();
             foreach (var item in split)
             {
-                var result = state.Parser.Evaluate($"={item}", state.FormatProvider, state.Context, state.FormattableStringParser);
+                var result = context.Parser.Evaluate($"={item}", context.FormatProvider, context.Context, context.FormattableStringParser);
                 if (!result.IsSuccessful())
                 {
                     return result;
                 }
-                builder.Append(result.Value.ToString(state.FormatProvider));
+                builder.Append(result.Value.ToString(context.FormatProvider));
             }
 
             return Result.Success<object?>(builder.ToString());
         });
     }
 
-    public Result<Type> Validate(ExpressionStringEvaluatorState state)
+    public Result<Type> Validate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
         return BaseProcessor.SplitDelimited
         (
-            state,
+            context,
             '&',
-            BaseProcessor.Parse(state)
+            BaseProcessor.Parse(context)
         );
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/EmptyExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/EmptyExpressionString.cs
@@ -2,11 +2,11 @@
 
 public class EmptyExpressionString : IExpressionString
 {
-    public Result<object?> Evaluate(ExpressionStringEvaluatorState state)
+    public Result<object?> Evaluate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (string.IsNullOrEmpty(state.Input))
+        if (string.IsNullOrEmpty(context.Input))
         {
             return Result.Success<object?>(string.Empty);
         }
@@ -14,11 +14,11 @@ public class EmptyExpressionString : IExpressionString
         return Result.Continue<object?>();
     }
 
-    public Result<Type> Validate(ExpressionStringEvaluatorState state)
+    public Result<Type> Validate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (string.IsNullOrEmpty(state.Input))
+        if (string.IsNullOrEmpty(context.Input))
         {
             return Result.Success(typeof(string));
         }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/FormattableStringExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/FormattableStringExpressionString.cs
@@ -10,7 +10,7 @@ public class FormattableStringExpressionString : IExpressionString
         {
             // =@"string value" -> literal, no functions but formattable strings possible
             return context.FormattableStringParser is not null
-                ? Result.FromExistingResult<GenericFormattableString, object?>(context.FormattableStringParser.Parse(context.Input.Substring(3, context.Input.Length - 4), new FormattableStringParserSettingsBuilder().WithFormatProvider(context.FormatProvider).Build(), context.Context), value => value.ToString(context.FormatProvider))
+                ? Result.FromExistingResult<GenericFormattableString, object?>(context.FormattableStringParser.Parse(context.Input.Substring(3, context.Input.Length - 4), new FormattableStringParserSettingsBuilder().WithFormatProvider(context.Settings.FormatProvider).Build(), context.Context), value => value.ToString(context.Settings.FormatProvider))
                 : Result.Success<object?>(context.Input.Substring(3, context.Input.Length - 4));
         }
         else if (context.Input.StartsWith("=\"") && context.Input.EndsWith("\""))
@@ -30,7 +30,7 @@ public class FormattableStringExpressionString : IExpressionString
         {
             // =@"string value" -> literal, no functions but formattable strings possible
             return context.FormattableStringParser is not null
-                ? Result.FromExistingResult(context.FormattableStringParser.Validate(context.Input.Substring(3, context.Input.Length - 4), new FormattableStringParserSettingsBuilder().WithFormatProvider(context.FormatProvider).Build(), context.Context), typeof(FormattableString))
+                ? Result.FromExistingResult(context.FormattableStringParser.Validate(context.Input.Substring(3, context.Input.Length - 4), new FormattableStringParserSettingsBuilder().WithFormatProvider(context.Settings.FormatProvider).Build(), context.Context), typeof(FormattableString))
                 : Result.Success(typeof(FormattableString));
         }
         else if (context.Input.StartsWith("=\"") && context.Input.EndsWith("\""))

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/FormattableStringExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/FormattableStringExpressionString.cs
@@ -2,38 +2,38 @@
 
 public class FormattableStringExpressionString : IExpressionString
 {
-    public Result<object?> Evaluate(ExpressionStringEvaluatorState state)
+    public Result<object?> Evaluate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (state.Input.StartsWith("=@\"") && state.Input.EndsWith("\""))
+        if (context.Input.StartsWith("=@\"") && context.Input.EndsWith("\""))
         {
             // =@"string value" -> literal, no functions but formattable strings possible
-            return state.FormattableStringParser is not null
-                ? Result.FromExistingResult<GenericFormattableString, object?>(state.FormattableStringParser.Parse(state.Input.Substring(3, state.Input.Length - 4), new FormattableStringParserSettingsBuilder().WithFormatProvider(state.FormatProvider).Build(), state.Context), value => value.ToString(state.FormatProvider))
-                : Result.Success<object?>(state.Input.Substring(3, state.Input.Length - 4));
+            return context.FormattableStringParser is not null
+                ? Result.FromExistingResult<GenericFormattableString, object?>(context.FormattableStringParser.Parse(context.Input.Substring(3, context.Input.Length - 4), new FormattableStringParserSettingsBuilder().WithFormatProvider(context.FormatProvider).Build(), context.Context), value => value.ToString(context.FormatProvider))
+                : Result.Success<object?>(context.Input.Substring(3, context.Input.Length - 4));
         }
-        else if (state.Input.StartsWith("=\"") && state.Input.EndsWith("\""))
+        else if (context.Input.StartsWith("=\"") && context.Input.EndsWith("\""))
         {
             // ="string value" -> literal, no functions and no formattable strings possible
-            return Result.Success<object?>(state.Input.Substring(2, state.Input.Length - 3));
+            return Result.Success<object?>(context.Input.Substring(2, context.Input.Length - 3));
         }
 
         return Result.Continue<object?>();
     }
 
-    public Result<Type> Validate(ExpressionStringEvaluatorState state)
+    public Result<Type> Validate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (state.Input.StartsWith("=@\"") && state.Input.EndsWith("\""))
+        if (context.Input.StartsWith("=@\"") && context.Input.EndsWith("\""))
         {
             // =@"string value" -> literal, no functions but formattable strings possible
-            return state.FormattableStringParser is not null
-                ? Result.FromExistingResult(state.FormattableStringParser.Validate(state.Input.Substring(3, state.Input.Length - 4), new FormattableStringParserSettingsBuilder().WithFormatProvider(state.FormatProvider).Build(), state.Context), typeof(FormattableString))
+            return context.FormattableStringParser is not null
+                ? Result.FromExistingResult(context.FormattableStringParser.Validate(context.Input.Substring(3, context.Input.Length - 4), new FormattableStringParserSettingsBuilder().WithFormatProvider(context.FormatProvider).Build(), context.Context), typeof(FormattableString))
                 : Result.Success(typeof(FormattableString));
         }
-        else if (state.Input.StartsWith("=\"") && state.Input.EndsWith("\""))
+        else if (context.Input.StartsWith("=\"") && context.Input.EndsWith("\""))
         {
             // ="string value" -> literal, no functions and no formattable strings possible
             return Result.Success(typeof(FormattableString));

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/LiteralExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/LiteralExpressionString.cs
@@ -2,36 +2,36 @@
 
 public class LiteralExpressionString : IExpressionString
 {
-    public Result<object?> Evaluate(ExpressionStringEvaluatorState state)
+    public Result<object?> Evaluate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (state.Input.StartsWith("\'="))
+        if (context.Input.StartsWith("\'="))
         {
             // escaped expression string
-            return Result.Success<object?>(state.Input.Substring(1));
+            return Result.Success<object?>(context.Input.Substring(1));
         }
 
-        if (!state.Input.StartsWith("="))
+        if (!context.Input.StartsWith("="))
         {
             // literal
-            return Result.Success<object?>(state.Input);
+            return Result.Success<object?>(context.Input);
         }
 
         return Result.Continue<object?>();
     }
 
-    public Result<Type> Validate(ExpressionStringEvaluatorState state)
+    public Result<Type> Validate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (state.Input.StartsWith("\'="))
+        if (context.Input.StartsWith("\'="))
         {
             // escaped expression string
             return Result.Success(typeof(string));
         }
 
-        if (!state.Input.StartsWith("="))
+        if (!context.Input.StartsWith("="))
         {
             // literal
             return Result.Success(typeof(string));

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/MathematicExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/MathematicExpressionString.cs
@@ -1,15 +1,15 @@
 ﻿namespace CrossCutting.Utilities.Parsers.ExpressionStrings;
 
-public class MathematicExpressionString(IMathematicExpressionEvaluator parser) : IExpressionString
+public class MathematicExpressionString(IMathematicExpressionEvaluator evaluator) : IExpressionString
 {
-    private readonly IMathematicExpressionEvaluator _parser = parser;
+    private readonly IMathematicExpressionEvaluator _evaluator = evaluator;
 
-    public Result<object?> Evaluate(ExpressionStringEvaluatorState state)
+    public Result<object?> Evaluate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
         // try =1+1 -> mathematic expression, no functions/formattable strings
-        var mathResult = _parser.Evaluate(state.Input.Substring(1), state.FormatProvider, state.Context);
+        var mathResult = _evaluator.Evaluate(context.Input.Substring(1), context.FormatProvider, context.Context);
         if (mathResult.Status is ResultStatus.Ok or not ResultStatus.NotFound)
         {
             // both success and failure need to be returned.
@@ -20,12 +20,12 @@ public class MathematicExpressionString(IMathematicExpressionEvaluator parser) :
         return Result.Continue<object?>();
     }
 
-    public Result<Type> Validate(ExpressionStringEvaluatorState state)
+    public Result<Type> Validate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
         // try =1+1 -> mathematic expression, no functions/formattable strings
-        var mathResult = _parser.Validate(state.Input.Substring(1), state.FormatProvider, state.Context);
+        var mathResult = _evaluator.Validate(context.Input.Substring(1), context.FormatProvider, context.Context);
         if (mathResult.Status is ResultStatus.Ok or not ResultStatus.NotFound)
         {
             // both success and failure need to be returned.

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/MathematicExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/MathematicExpressionString.cs
@@ -9,7 +9,7 @@ public class MathematicExpressionString(IMathematicExpressionEvaluator evaluator
         context = ArgumentGuard.IsNotNull(context, nameof(context));
 
         // try =1+1 -> mathematic expression, no functions/formattable strings
-        var mathResult = _evaluator.Evaluate(context.Input.Substring(1), context.FormatProvider, context.Context);
+        var mathResult = _evaluator.Evaluate(context.Input.Substring(1), context.Settings.FormatProvider, context.Context);
         if (mathResult.Status is ResultStatus.Ok or not ResultStatus.NotFound)
         {
             // both success and failure need to be returned.
@@ -25,7 +25,7 @@ public class MathematicExpressionString(IMathematicExpressionEvaluator evaluator
         context = ArgumentGuard.IsNotNull(context, nameof(context));
 
         // try =1+1 -> mathematic expression, no functions/formattable strings
-        var mathResult = _evaluator.Validate(context.Input.Substring(1), context.FormatProvider, context.Context);
+        var mathResult = _evaluator.Validate(context.Input.Substring(1), context.Settings.FormatProvider, context.Context);
         if (mathResult.Status is ResultStatus.Ok or not ResultStatus.NotFound)
         {
             // both success and failure need to be returned.

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/OnlyEqualsExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/OnlyEqualsExpressionString.cs
@@ -2,23 +2,23 @@
 
 public class OnlyEqualsExpressionString : IExpressionString
 {
-    public Result<object?> Evaluate(ExpressionStringEvaluatorState state)
+    public Result<object?> Evaluate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (state.Input == "=")
+        if (context.Input == "=")
         {
-            return Result.Success<object?>(state.Input);
+            return Result.Success<object?>(context.Input);
         }
 
         return Result.Continue<object?>();
     }
 
-    public Result<Type> Validate(ExpressionStringEvaluatorState state)
+    public Result<Type> Validate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (state.Input == "=")
+        if (context.Input == "=")
         {
             return Result.Success(typeof(string));
         }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/Operators/OperatorExpressionProcessorBase.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/Operators/OperatorExpressionProcessorBase.cs
@@ -4,28 +4,28 @@ public abstract class OperatorExpressionProcessorBase : IExpressionString
 {
     protected abstract string Sign { get; }
 
-    public Result<object?> Evaluate(ExpressionStringEvaluatorState state)
+    public Result<object?> Evaluate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (state.Input.IndexOf(Sign) == -1)
+        if (context.Input.IndexOf(Sign) == -1)
         {
             return Result.Continue<object?>();
         }
 
-        var split = state.Input.Substring(1).SplitDelimited(Sign, '\"', true, true);
+        var split = context.Input.Substring(1).SplitDelimited(Sign, '\"', true, true);
         if (split.Length != 2)
         {
             return Result.Continue<object?>();
         }
 
-        var leftResult = state.Parser.Evaluate($"={split[0]}", state.FormatProvider, state.Context, state.FormattableStringParser);
+        var leftResult = context.Parser.Evaluate($"={split[0]}", context.FormatProvider, context.Context, context.FormattableStringParser);
         if (!leftResult.IsSuccessful())
         {
             return leftResult;
         }
 
-        var rightResult = state.Parser.Evaluate($"={split[1]}", state.FormatProvider, state.Context, state.FormattableStringParser);
+        var rightResult = context.Parser.Evaluate($"={split[1]}", context.FormatProvider, context.Context, context.FormattableStringParser);
         if (!rightResult.IsSuccessful())
         {
             return rightResult;
@@ -34,28 +34,28 @@ public abstract class OperatorExpressionProcessorBase : IExpressionString
         return Result.FromExistingResult<object?>(PerformOperator(leftResult.Value, rightResult.Value));
     }
 
-    public Result<Type> Validate(ExpressionStringEvaluatorState state)
+    public Result<Type> Validate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        if (state.Input.IndexOf(Sign) == -1)
+        if (context.Input.IndexOf(Sign) == -1)
         {
             return Result.Continue<Type>();
         }
 
-        var split = state.Input.Substring(1).SplitDelimited(Sign, '\"', true, true);
+        var split = context.Input.Substring(1).SplitDelimited(Sign, '\"', true, true);
         if (split.Length != 2)
         {
             return Result.Continue<Type>();
         }
 
-        var leftResult = state.Parser.Validate($"={split[0]}", state.FormatProvider, state.Context, state.FormattableStringParser);
+        var leftResult = context.Parser.Validate($"={split[0]}", context.FormatProvider, context.Context, context.FormattableStringParser);
         if (!leftResult.IsSuccessful())
         {
             return leftResult;
         }
 
-        var rightResult = state.Parser.Validate($"={split[1]}", state.FormatProvider, state.Context, state.FormattableStringParser);
+        var rightResult = context.Parser.Validate($"={split[1]}", context.FormatProvider, context.Context, context.FormattableStringParser);
         if (!rightResult.IsSuccessful())
         {
             return rightResult;

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/Operators/OperatorExpressionProcessorBase.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/Operators/OperatorExpressionProcessorBase.cs
@@ -19,13 +19,13 @@ public abstract class OperatorExpressionProcessorBase : IExpressionString
             return Result.Continue<object?>();
         }
 
-        var leftResult = context.Parser.Evaluate($"={split[0]}", context.FormatProvider, context.Context, context.FormattableStringParser);
+        var leftResult = context.Parser.Evaluate($"={split[0]}", context.Settings, context.Context, context.FormattableStringParser);
         if (!leftResult.IsSuccessful())
         {
             return leftResult;
         }
 
-        var rightResult = context.Parser.Evaluate($"={split[1]}", context.FormatProvider, context.Context, context.FormattableStringParser);
+        var rightResult = context.Parser.Evaluate($"={split[1]}", context.Settings, context.Context, context.FormattableStringParser);
         if (!rightResult.IsSuccessful())
         {
             return rightResult;
@@ -49,13 +49,13 @@ public abstract class OperatorExpressionProcessorBase : IExpressionString
             return Result.Continue<Type>();
         }
 
-        var leftResult = context.Parser.Validate($"={split[0]}", context.FormatProvider, context.Context, context.FormattableStringParser);
+        var leftResult = context.Parser.Validate($"={split[0]}", context.Settings, context.Context, context.FormattableStringParser);
         if (!leftResult.IsSuccessful())
         {
             return leftResult;
         }
 
-        var rightResult = context.Parser.Validate($"={split[1]}", context.FormatProvider, context.Context, context.FormattableStringParser);
+        var rightResult = context.Parser.Validate($"={split[1]}", context.Settings, context.Context, context.FormattableStringParser);
         if (!rightResult.IsSuccessful())
         {
             return rightResult;

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/PipedExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/PipedExpressionString.cs
@@ -2,16 +2,16 @@
 
 public class PipedExpressionString : IExpressionString
 {
-    public Result<object?> Evaluate(ExpressionStringEvaluatorState state)
+    public Result<object?> Evaluate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        return BaseProcessor.SplitDelimited(state, '|', split =>
+        return BaseProcessor.SplitDelimited(context, '|', split =>
         {
-            var resultValue = state.Context;
+            var resultValue = context.Context;
             foreach (var item in split)
             {
-                var result = state.Parser.Evaluate($"={item}", state.FormatProvider, resultValue, state.FormattableStringParser);
+                var result = context.Parser.Evaluate($"={item}", context.FormatProvider, resultValue, context.FormattableStringParser);
                 if (!result.IsSuccessful())
                 {
                     return result;
@@ -23,15 +23,15 @@ public class PipedExpressionString : IExpressionString
         });
     }
 
-    public Result<Type> Validate(ExpressionStringEvaluatorState state)
+    public Result<Type> Validate(ExpressionStringEvaluatorContext context)
     {
-        state = ArgumentGuard.IsNotNull(state, nameof(state));
+        context = ArgumentGuard.IsNotNull(context, nameof(context));
 
         return BaseProcessor.SplitDelimited
         (
-            state,
+            context,
             '|',
-            BaseProcessor.Parse(state)
+            BaseProcessor.Parse(context)
         );
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/ExpressionStrings/PipedExpressionString.cs
+++ b/src/CrossCutting.Utilities.Parsers/ExpressionStrings/PipedExpressionString.cs
@@ -11,7 +11,7 @@ public class PipedExpressionString : IExpressionString
             var resultValue = context.Context;
             foreach (var item in split)
             {
-                var result = context.Parser.Evaluate($"={item}", context.FormatProvider, resultValue, context.FormattableStringParser);
+                var result = context.Parser.Evaluate($"={item}", context.Settings, resultValue, context.FormattableStringParser);
                 if (!result.IsSuccessful())
                 {
                     return result;

--- a/src/CrossCutting.Utilities.Parsers/Extensions/ExpressionStringEvaluatorExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/ExpressionStringEvaluatorExtensions.cs
@@ -2,21 +2,21 @@
 
 public static class ExpressionStringEvaluatorExtensions
 {
-    public static Result<object?> Evaluate(this IExpressionStringEvaluator instance, string input, IFormatProvider formatProvider)
-        => instance.Evaluate(input, formatProvider, null, null);
+    public static Result<object?> Evaluate(this IExpressionStringEvaluator instance, string input, ExpressionStringEvaluatorSettings settings)
+        => instance.Evaluate(input, settings, null, null);
 
-    public static Result<object?> Evaluate(this IExpressionStringEvaluator instance, string input, IFormatProvider formatProvider, IFormattableStringParser formattableStringParser)
-        => instance.Evaluate(input, formatProvider, null, formattableStringParser);
+    public static Result<object?> Evaluate(this IExpressionStringEvaluator instance, string input, ExpressionStringEvaluatorSettings settings, IFormattableStringParser formattableStringParser)
+        => instance.Evaluate(input, settings, null, formattableStringParser);
 
-    public static Result<object?> Evaluate(this IExpressionStringEvaluator instance, string input, IFormatProvider formatProvider, object? context)
-        => instance.Evaluate(input, formatProvider, context, null);
+    public static Result<object?> Evaluate(this IExpressionStringEvaluator instance, string input, ExpressionStringEvaluatorSettings settings, object? context)
+        => instance.Evaluate(input, settings, context, null);
 
-    public static Result<Type> Validate(this IExpressionStringEvaluator instance, string input, IFormatProvider formatProvider)
-        => instance.Validate(input, formatProvider, null, null);
+    public static Result<Type> Validate(this IExpressionStringEvaluator instance, string input, ExpressionStringEvaluatorSettings settings)
+        => instance.Validate(input, settings, null, null);
 
-    public static Result<Type> Validate(this IExpressionStringEvaluator instance, string input, IFormatProvider formatProvider, IFormattableStringParser formattableStringParser)
-        => instance.Validate(input, formatProvider, null, formattableStringParser);
+    public static Result<Type> Validate(this IExpressionStringEvaluator instance, string input, ExpressionStringEvaluatorSettings settings, IFormattableStringParser formattableStringParser)
+        => instance.Validate(input, settings, null, formattableStringParser);
 
-    public static Result<Type> Validate(this IExpressionStringEvaluator instance, string input, IFormatProvider formatProvider, object? context)
-        => instance.Validate(input, formatProvider, context, null);
+    public static Result<Type> Validate(this IExpressionStringEvaluator instance, string input, ExpressionStringEvaluatorSettings settings, object? context)
+        => instance.Validate(input, settings, context, null);
 }

--- a/src/CrossCutting.Utilities.Parsers/Extensions/FunctionEvaluatorExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/FunctionEvaluatorExtensions.cs
@@ -2,30 +2,12 @@
 
 public static class FunctionEvaluatorExtensions
 {
-    public static Result<Type> Validate(this IFunctionEvaluator instance, FunctionCall functionCall)
-        => instance.Validate(functionCall, CultureInfo.InvariantCulture, null);
+    public static Result<Type> Validate(this IFunctionEvaluator instance, FunctionCall functionCall, FunctionEvaluatorSettings settings)
+        => instance.Validate(functionCall, settings, null);
 
-    public static Result<Type> Validate(this IFunctionEvaluator instance, FunctionCall functionCall, IFormatProvider formatProvider)
-        => instance.Validate(functionCall, formatProvider, null);
+    public static Result<object?> Evaluate(this IFunctionEvaluator instance, FunctionCall functionCall, FunctionEvaluatorSettings settings)
+        => instance.Evaluate(functionCall, settings, null);
 
-    public static Result<Type> Validate(this IFunctionEvaluator instance, FunctionCall functionCall, object? context)
-        => instance.Validate(functionCall, CultureInfo.InvariantCulture, context);
-
-    public static Result<object?> Evaluate(this IFunctionEvaluator instance, FunctionCall functionCall)
-        => instance.Evaluate(functionCall, CultureInfo.InvariantCulture, null);
-
-    public static Result<object?> Evaluate(this IFunctionEvaluator instance, FunctionCall functionCall, IFormatProvider formatProvider)
-        => instance.Evaluate(functionCall, formatProvider, null);
-
-    public static Result<object?> Evaluate(this IFunctionEvaluator instance, FunctionCall functionCall, object? context)
-        => instance.Evaluate(functionCall, CultureInfo.InvariantCulture, context);
-
-    public static Result<T> EvaluateTyped<T>(this IFunctionEvaluator instance, FunctionCall functionCall)
-        => instance.EvaluateTyped<T>(functionCall, CultureInfo.InvariantCulture, null);
-
-    public static Result<T> EvaluateTyped<T>(this IFunctionEvaluator instance, FunctionCall functionCall, IFormatProvider formatProvider)
-        => instance.EvaluateTyped<T>(functionCall, formatProvider, null);
-
-    public static Result<T> EvaluateTyped<T>(this IFunctionEvaluator instance, FunctionCall functionCall, object? context)
-        => instance.EvaluateTyped<T>(functionCall, CultureInfo.InvariantCulture, context);
+    public static Result<T> EvaluateTyped<T>(this IFunctionEvaluator instance, FunctionCall functionCall, FunctionEvaluatorSettings settings)
+        => instance.EvaluateTyped<T>(functionCall, settings, null);
 }

--- a/src/CrossCutting.Utilities.Parsers/Extensions/FunctionParserExtensions.cs
+++ b/src/CrossCutting.Utilities.Parsers/Extensions/FunctionParserExtensions.cs
@@ -3,11 +3,11 @@
 public static class FunctionParserExtensions
 {
     public static Result<FunctionCall> Parse(this IFunctionParser instance, string input, IFormatProvider formatProvider)
-        => instance.Parse(input, formatProvider, null, null);
+        => instance.Parse(input, new FunctionParserSettings(formatProvider, null), null);
 
     public static Result<FunctionCall> Parse(this IFunctionParser instance, string input, IFormatProvider formatProvider, IFormattableStringParser formattableStringParser)
-        => instance.Parse(input, formatProvider, formattableStringParser, null);
+        => instance.Parse(input, new FunctionParserSettings(formatProvider, formattableStringParser), null);
 
     public static Result<FunctionCall> Parse(this IFunctionParser instance, string input, IFormatProvider formatProvider, object? context)
-        => instance.Parse(input, formatProvider, null, context);
+        => instance.Parse(input, new FunctionParserSettings(formatProvider, null), context);
 }

--- a/src/CrossCutting.Utilities.Parsers/FormattableStringParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/FormattableStringParser.cs
@@ -117,8 +117,8 @@ public class FormattableStringParser : IFormattableStringParser
     private Result<GenericFormattableString> ProcessOnPlaceholders(FormattableStringParserSettings settings, object? context, bool validateOnly, string value)
         => _placeholders
             .Select(placeholder => validateOnly
-                ? Result.FromExistingResult<GenericFormattableString>(placeholder.Validate(value, settings.FormatProvider, context, this))
-                : placeholder.Evaluate(value, settings.FormatProvider, context, this))
+                ? Result.FromExistingResult<GenericFormattableString>(placeholder.Validate(value, new PlaceholderSettings(settings.FormatProvider, settings.ValidateArgumentTypes), context, this))
+                : placeholder.Evaluate(value, new PlaceholderSettings(settings.FormatProvider, settings.ValidateArgumentTypes), context, this))
             .FirstOrDefault(x => x.Status != ResultStatus.Continue)
                 ?? Result.Invalid<GenericFormattableString>($"Unknown placeholder in value: {value}");
 

--- a/src/CrossCutting.Utilities.Parsers/FunctionCall.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionCall.cs
@@ -115,7 +115,7 @@ public partial record FunctionCall
             return Result.Invalid<int>($"{argumentName} is not of type integer");
         }
 
-        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.FormatProvider, context.Context);
+        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.Settings.FormatProvider, context.Context);
         if (!parseResult.IsSuccessful())
         {
             return Result.Invalid<int>($"{argumentName} is not of type integer");
@@ -143,7 +143,7 @@ public partial record FunctionCall
             return Result.Invalid<long>($"{argumentName} is not of type long integer");
         }
 
-        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.FormatProvider, context.Context);
+        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.Settings.FormatProvider, context.Context);
         if (!parseResult.IsSuccessful())
         {
             return Result.Invalid<long>($"{argumentName} is not of type long integer");
@@ -171,7 +171,7 @@ public partial record FunctionCall
             return Result.Invalid<decimal>($"{argumentName} is not of type decimal");
         }
 
-        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.FormatProvider, context.Context);
+        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.Settings.FormatProvider, context.Context);
         if (!parseResult.IsSuccessful())
         {
             return Result.Invalid<decimal>($"{argumentName} is not of type decimal");
@@ -199,7 +199,7 @@ public partial record FunctionCall
             return Result.Invalid<bool>($"{argumentName} is not of type boolean");
         }
 
-        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.FormatProvider, context.Context);
+        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.Settings.FormatProvider, context.Context);
         if (!parseResult.IsSuccessful())
         {
             return Result.Invalid<bool>($"{argumentName} is not of type boolean");
@@ -226,7 +226,7 @@ public partial record FunctionCall
         {
             return Result.Invalid<DateTime>($"{argumentName} is not of type datetime");
         }
-        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.FormatProvider, context.Context);
+        var parseResult = context.ExpressionEvaluator.Evaluate(s, context.Settings.FormatProvider, context.Context);
         if (!parseResult.IsSuccessful())
         {
             return Result.Invalid<DateTime>($"{argumentName} is not of type datetime");

--- a/src/CrossCutting.Utilities.Parsers/FunctionCallArgumentValidator.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionCallArgumentValidator.cs
@@ -13,7 +13,7 @@ public class FunctionCallArgumentValidator : IFunctionCallArgumentValidator
         {
             return callArgumentResult;
         }
-        else if (!IsTypeValid(descriptorArgument, callArgumentResult))
+        else if (functionCallContext.Settings.ValidateArgumentTypes && !IsTypeValid(descriptorArgument, callArgumentResult))
         {
             return Result.Invalid<Type>($"Argument {descriptorArgument.Name} is not of type {descriptorArgument.Type.FullName}");
         }

--- a/src/CrossCutting.Utilities.Parsers/FunctionCallArguments/ExpressionArgument.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionCallArguments/ExpressionArgument.cs
@@ -6,7 +6,7 @@ public partial record ExpressionArgument
     {
         context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        var result = context.ExpressionEvaluator.Evaluate(Value, context.FormatProvider, context.Context);
+        var result = context.ExpressionEvaluator.Evaluate(Value, context.Settings.FormatProvider, context.Context);
 
         return result.Status == ResultStatus.NotSupported
             ? Result.Success<object?>(Value)
@@ -17,7 +17,7 @@ public partial record ExpressionArgument
     {
         context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        var result = context.ExpressionEvaluator.Validate(Value, context.FormatProvider, context.Context);
+        var result = context.ExpressionEvaluator.Validate(Value, context.Settings.FormatProvider, context.Context);
 
         return result.Status == ResultStatus.Invalid && result.ErrorMessage?.StartsWith("Unknown expression type found in fragment:") == true
             ? Result.Continue(typeof(string))

--- a/src/CrossCutting.Utilities.Parsers/FunctionCallArguments/FunctionArgument.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionCallArguments/FunctionArgument.cs
@@ -6,13 +6,13 @@ public partial record FunctionArgument
     {
         context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        return context.FunctionEvaluator.Evaluate(Function, context.FormatProvider, context.Context);
+        return context.FunctionEvaluator.Evaluate(Function, context.Settings, context.Context);
     }
 
     public override Result<Type> Validate(FunctionCallContext context)
     {
         context = ArgumentGuard.IsNotNull(context, nameof(context));
 
-        return context.FunctionEvaluator.Validate(Function, context.FormatProvider, context.Context);
+        return context.FunctionEvaluator.Validate(Function, context.Settings, context.Context);
     }
 }

--- a/src/CrossCutting.Utilities.Parsers/FunctionCallContext.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionCallContext.cs
@@ -4,10 +4,15 @@ public class FunctionCallContext
 {
     public FunctionCallContext(FunctionCall functionCall, IFunctionEvaluator functionEvaluator, IExpressionEvaluator expressionEvaluator, IFormatProvider formatProvider, object? context)
     {
-        FunctionCall = functionCall ?? throw new ArgumentNullException(nameof(functionCall));
-        FunctionEvaluator = functionEvaluator ?? throw new ArgumentNullException(nameof(functionEvaluator));
-        ExpressionEvaluator = expressionEvaluator ?? throw new ArgumentNullException(nameof(expressionEvaluator));
-        FormatProvider = formatProvider ?? throw new ArgumentNullException(nameof(formatProvider));
+        ArgumentGuard.IsNotNull(functionCall, nameof(functionCall));
+        ArgumentGuard.IsNotNull(functionEvaluator, nameof(functionEvaluator));
+        ArgumentGuard.IsNotNull(expressionEvaluator, nameof(expressionEvaluator));
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+
+        FunctionCall = functionCall;
+        FunctionEvaluator = functionEvaluator;
+        ExpressionEvaluator = expressionEvaluator;
+        FormatProvider = formatProvider;
         Context = context;
     }
 

--- a/src/CrossCutting.Utilities.Parsers/FunctionCallContext.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionCallContext.cs
@@ -2,24 +2,24 @@
 
 public class FunctionCallContext
 {
-    public FunctionCallContext(FunctionCall functionCall, IFunctionEvaluator functionEvaluator, IExpressionEvaluator expressionEvaluator, IFormatProvider formatProvider, object? context)
+    public FunctionCallContext(FunctionCall functionCall, IFunctionEvaluator functionEvaluator, IExpressionEvaluator expressionEvaluator, FunctionEvaluatorSettings settings, object? context)
     {
         ArgumentGuard.IsNotNull(functionCall, nameof(functionCall));
         ArgumentGuard.IsNotNull(functionEvaluator, nameof(functionEvaluator));
         ArgumentGuard.IsNotNull(expressionEvaluator, nameof(expressionEvaluator));
-        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+        ArgumentGuard.IsNotNull(settings, nameof(settings));
 
         FunctionCall = functionCall;
         FunctionEvaluator = functionEvaluator;
         ExpressionEvaluator = expressionEvaluator;
-        FormatProvider = formatProvider;
+        Settings = settings;
         Context = context;
     }
 
     public FunctionCall FunctionCall { get; }
     public IFunctionEvaluator FunctionEvaluator { get; }
     public IExpressionEvaluator ExpressionEvaluator { get; }
-    public IFormatProvider FormatProvider { get; }
+    public FunctionEvaluatorSettings Settings { get; }
     public object? Context { get; }
 
     public Result<object?> GetArgumentValueResult(int index, string argumentName)

--- a/src/CrossCutting.Utilities.Parsers/FunctionEvaluator.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionEvaluator.cs
@@ -33,26 +33,26 @@ public class FunctionEvaluator : IFunctionEvaluator
         _functions = functions;
     }
 
-    public Result<object?> Evaluate(FunctionCall functionCall, IFormatProvider formatProvider, object? context)
+    public Result<object?> Evaluate(FunctionCall functionCall, FunctionEvaluatorSettings settings, object? context)
     {
         if (functionCall is null)
         {
             return Result.Invalid<object?>("Function call is required");
         }
 
-        var functionCallContext = new FunctionCallContext(functionCall, this, _expressionEvaluator, formatProvider, context);
+        var functionCallContext = new FunctionCallContext(functionCall, this, _expressionEvaluator, settings, context);
 
         return ResolveFunction(functionCallContext).Transform(result => result.Function.Evaluate(functionCallContext));
     }
 
-    public Result<T> EvaluateTyped<T>(FunctionCall functionCall, IFormatProvider formatProvider, object? context)
+    public Result<T> EvaluateTyped<T>(FunctionCall functionCall, FunctionEvaluatorSettings settings, object? context)
     {
         if (functionCall is null)
         {
             return Result.Invalid<T>("Function call is required");
         }
 
-        var functionCallContext = new FunctionCallContext(functionCall, this, _expressionEvaluator, formatProvider, context);
+        var functionCallContext = new FunctionCallContext(functionCall, this, _expressionEvaluator, settings, context);
 
         var functionResult = ResolveFunction(functionCallContext);
         if (functionResult.Value?.Function is ITypedFunction<T> typedFunction)
@@ -63,14 +63,14 @@ public class FunctionEvaluator : IFunctionEvaluator
         return functionResult.Transform(result => result.Function.Evaluate(functionCallContext).TryCast<T>());
     }
 
-    public Result<Type> Validate(FunctionCall functionCall, IFormatProvider formatProvider, object? context)
+    public Result<Type> Validate(FunctionCall functionCall, FunctionEvaluatorSettings settings, object? context)
     {
         if (functionCall is null)
         {
             return Result.Invalid<Type>("Function call is required");
         }
 
-        var functionCallContext = new FunctionCallContext(functionCall, this, _expressionEvaluator, formatProvider, context);
+        var functionCallContext = new FunctionCallContext(functionCall, this, _expressionEvaluator, settings, context);
 
         return ResolveFunction(functionCallContext)
             .Transform(result => (result.Value?.Function as IValidatableFunction)?.Validate(functionCallContext) ?? Result.FromExistingResult(result, result.Value?.ReturnValueType ?? typeof(object)));

--- a/src/CrossCutting.Utilities.Parsers/FunctionParser.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParser.cs
@@ -18,9 +18,9 @@ public class FunctionParser : IFunctionParser
         _argumentProcessors = argumentProcessors;
     }
 
-    public Result<FunctionCall> Parse(string function, IFormatProvider formatProvider, IFormattableStringParser? formattableStringParser, object? context)
+    public Result<FunctionCall> Parse(string function, FunctionParserSettings settings, object? context)
     {
-        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+        ArgumentGuard.IsNotNull(settings, nameof(settings));
 
         if (string.IsNullOrEmpty(function))
         {
@@ -61,7 +61,7 @@ public class FunctionParser : IFunctionParser
                 .Select(RemoveStringQualifiers);
 
             var arguments = new List<FunctionCallArgument>();
-            var addArgumentsResult = AddArguments(results, stringArgumentsSplit, arguments, formatProvider, formattableStringParser, context);
+            var addArgumentsResult = AddArguments(results, stringArgumentsSplit, arguments, settings, context);
             if (!addArgumentsResult.IsSuccessful())
             {
                 return addArgumentsResult;
@@ -119,7 +119,7 @@ public class FunctionParser : IFunctionParser
         }
     }
 
-    private Result<FunctionCall> AddArguments(List<FunctionCall> results, IEnumerable<string> argumentsSplit, List<FunctionCallArgument> arguments, IFormatProvider formatProvider, IFormattableStringParser? formattableStringParser, object? context)
+    private Result<FunctionCall> AddArguments(List<FunctionCall> results, IEnumerable<string> argumentsSplit, List<FunctionCallArgument> arguments, FunctionParserSettings settings, object? context)
     {
         foreach (var argument in argumentsSplit)
         {
@@ -130,7 +130,7 @@ public class FunctionParser : IFunctionParser
             }
 
             var processValueResult = _argumentProcessors
-                .Select(x => x.Process(argument, results, formatProvider, formattableStringParser, context))
+                .Select(x => x.Process(argument, results, settings, context))
                 .FirstOrDefault(x => x.Status != ResultStatus.Continue);
             if (processValueResult is not null)
             {

--- a/src/CrossCutting.Utilities.Parsers/FunctionParserArgumentProcessors/FormattableStringFunctionParserArgumentProcessor.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParserArgumentProcessors/FormattableStringFunctionParserArgumentProcessor.cs
@@ -2,13 +2,15 @@
 
 public class FormattableStringFunctionParserArgumentProcessor : IFunctionParserArgumentProcessor
 {
-    public Result<FunctionCallArgument> Process(string argument, IReadOnlyCollection<FunctionCall> functionCalls, IFormatProvider formatProvider, IFormattableStringParser? formattableStringParser, object? context)
+    public Result<FunctionCallArgument> Process(string argument, IReadOnlyCollection<FunctionCall> functionCalls, FunctionParserSettings settings, object? context)
     {
-        if (argument?.StartsWith("@") == true && formattableStringParser is not null)
+        settings = settings.IsNotNull(nameof(settings));
+
+        if (argument?.StartsWith("@") == true && settings.FormattableStringParser is not null)
         {
-            var result = formattableStringParser.Parse(argument.Substring(1), new FormattableStringParserSettingsBuilder().WithFormatProvider(formatProvider).Build(), context);
+            var result = settings.FormattableStringParser.Parse(argument.Substring(1), new FormattableStringParserSettingsBuilder().WithFormatProvider(settings.FormatProvider).Build(), context);
             return result.IsSuccessful()
-                ? Result.Success<FunctionCallArgument>(new ExpressionArgument(result.Value!.ToString(formatProvider)))
+                ? Result.Success<FunctionCallArgument>(new ExpressionArgument(result.Value!.ToString(settings.FormatProvider)))
                 : Result.FromExistingResult<FunctionCallArgument>(result);
         }
 

--- a/src/CrossCutting.Utilities.Parsers/FunctionParserSettings.cs
+++ b/src/CrossCutting.Utilities.Parsers/FunctionParserSettings.cs
@@ -1,0 +1,15 @@
+﻿namespace CrossCutting.Utilities.Parsers;
+
+public class FunctionParserSettings
+{
+    public FunctionParserSettings(IFormatProvider formatProvider, IFormattableStringParser? formattableStringParser)
+    {
+        ArgumentGuard.IsNotNull(formatProvider, nameof(formatProvider));
+
+        FormatProvider = formatProvider;
+        FormattableStringParser = formattableStringParser;
+    }
+
+    public IFormatProvider FormatProvider { get; }
+    public IFormattableStringParser? FormattableStringParser { get; }
+}

--- a/src/CrossCutting.Utilities.Parsers/Placeholders/ExpressionStringPlaceholder.cs
+++ b/src/CrossCutting.Utilities.Parsers/Placeholders/ExpressionStringPlaceholder.cs
@@ -11,9 +11,11 @@ public class ExpressionStringPlaceholder : IPlaceholder
         _expressionStringEvaluator = expressionStringEvaluator;
     }
 
-    public Result<GenericFormattableString> Evaluate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+    public Result<GenericFormattableString> Evaluate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser)
     {
-        var result = _expressionStringEvaluator.Evaluate($"={value}", formatProvider, context, formattableStringParser);
+        settings = ArgumentGuard.IsNotNull(settings, nameof(settings));
+
+        var result = _expressionStringEvaluator.Evaluate($"={value}", new ExpressionStringEvaluatorSettings(settings.FormatProvider, settings.ValidateArgumentTypes), context, formattableStringParser);
 
         return result.Status switch
         {
@@ -22,9 +24,11 @@ public class ExpressionStringPlaceholder : IPlaceholder
         };
     }
 
-    public Result Validate(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
+    public Result Validate(string value, PlaceholderSettings settings, object? context, IFormattableStringParser formattableStringParser)
     {
-        var result = _expressionStringEvaluator.Validate($"={value}", formatProvider, context, formattableStringParser);
+        settings = ArgumentGuard.IsNotNull(settings, nameof(settings));
+
+        var result = _expressionStringEvaluator.Validate($"={value}", new ExpressionStringEvaluatorSettings(settings.FormatProvider, settings.ValidateArgumentTypes), context, formattableStringParser);
 
         return result.Status switch
         {


### PR DESCRIPTION
If you want to skip argument type validation (like in ExpressionFramework, where you do your own type checking), then you can now skip it.

Note that this involves a major version bump because it's a breaking change.

But, the good news is: We now have Settings classes, which we can extend without breaking it brutally. Just use Builders to create them, and we will include sensible default values there.