### PR TITLE
AsyncResultDictionaryBuilder improvements

### DIFF
--- a/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
+++ b/src/CrossCutting.CodeGeneration/CrossCutting.CodeGeneration.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.21.7" />
-    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="2.0.13" />
+    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="2.0.14" />
   </ItemGroup>
 
 </Project>

--- a/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
+++ b/src/CrossCutting.Common.Tests/CrossCutting.Common.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/CrossCutting.Common.Tests/Results/AsyncResultDictionaryBuilderTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/AsyncResultDictionaryBuilderTests.cs
@@ -272,6 +272,58 @@ public class AsyncResultDictionaryBuilderTests
                 result.Count.ShouldBe(2);
             }
         }
+
+        public class BuildLazy : NonGeneric
+        {
+            [Fact]
+            public async Task Builds_Results_Correctly()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test1", NonGenericTask);
+                sut.Add("Test2", GenericTask);
+
+                // Act
+                var result = await sut.BuildLazy();
+
+                // Assert
+                result.Count.ShouldBe(2);
+            }
+
+            [Fact]
+            public async Task Stops_On_First_NonSuccessful_Result()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test1", NonGenericTask);
+                sut.Add("Test2", GenericErrorTask); // This one returns an error
+                sut.Add("Test3", GenericTask); // This one will not get executed because of the error
+
+                // Act
+                var result = await sut.BuildLazy();
+
+                // Assert
+                result.Count.ShouldBe(2);
+                result.Keys.ToArray().ShouldBeEquivalentTo(new[] { "Test1", "Test2" });
+            }
+
+            [Fact]
+            public async Task Wraps_Exception_In_Error()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test1", NonGenericTask);
+                sut.Add("Test2", GenericExceptionTask); // This one returns an error
+                sut.Add("Test3", GenericTask); // This one will not get executed because of the error
+
+                // Act
+                var result = await sut.BuildLazy();
+
+                // Assert
+                result.Count.ShouldBe(2);
+                result.Keys.ToArray().ShouldBeEquivalentTo(new[] { "Test1", "Test2" });
+            }
+        }
     }
 
     public class Generic : AsyncResultDictionaryBuilderTests
@@ -436,6 +488,58 @@ public class AsyncResultDictionaryBuilderTests
 
                 // Assert
                 result.Count.ShouldBe(2);
+            }
+        }
+
+        public class BuildLazy : Generic
+        {
+            [Fact]
+            public async Task Builds_Results_Correctly()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+                sut.Add("Test1", GenericTask);
+                sut.Add("Test2", GenericTask);
+
+                // Act
+                var result = await sut.BuildLazy();
+
+                // Assert
+                result.Count.ShouldBe(2);
+            }
+
+            [Fact]
+            public async Task Stops_On_First_NonSuccessful_Result()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+                sut.Add("Test1", GenericTask);
+                sut.Add("Test2", GenericErrorTask); // This one returns an error
+                sut.Add("Test3", GenericTask); // This one will not get executed because of the error
+
+                // Act
+                var result = await sut.BuildLazy();
+
+                // Assert
+                result.Count.ShouldBe(2);
+                result.Keys.ToArray().ShouldBeEquivalentTo(new[] { "Test1", "Test2" });
+            }
+
+            [Fact]
+            public async Task Wraps_Exception_In_Error()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+                sut.Add("Test1", GenericTask);
+                sut.Add("Test2", GenericExceptionTask); // This one returns an error
+                sut.Add("Test3", GenericTask); // This one will not get executed because of the error
+
+                // Act
+                var result = await sut.BuildLazy();
+
+                // Assert
+                result.Count.ShouldBe(2);
+                result.Keys.ToArray().ShouldBeEquivalentTo(new[] { "Test1", "Test2" });
             }
         }
     }

--- a/src/CrossCutting.Common.Tests/Results/AsyncResultDictionaryBuilderTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/AsyncResultDictionaryBuilderTests.cs
@@ -203,6 +203,192 @@ public class AsyncResultDictionaryBuilderTests
             }
         }
 
+        public class AddRange_Untyped_Task : NonGeneric
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+
+                // Act
+                sut.AddRange("Test", [NonGenericTask]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test0", NonGenericTask);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [NonGenericTask]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Typed_Task : NonGeneric
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+
+                // Act
+                sut.AddRange("Test", [GenericTask]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test0", GenericTask);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [GenericTask]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Untyped_Func : NonGeneric
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+
+                // Act
+                sut.AddRange("Test", [NonGenericFunc]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test0", NonGenericFunc);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [NonGenericFunc]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Typed_Func : NonGeneric
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+
+                // Act
+                sut.AddRange("Test", [GenericFunc]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test0", GenericFunc);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [GenericFunc]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Untyped_Result : NonGeneric
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+
+                // Act
+                sut.AddRange("Test", [NonGenericResult]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test0", NonGenericResult);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [NonGenericResult]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Typed_Result : NonGeneric
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+
+                // Act
+                sut.AddRange("Test", [GenericResult]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test0", GenericResult);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [GenericResult]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
         public class Build : NonGeneric
         {
             [Fact]
@@ -418,6 +604,99 @@ public class AsyncResultDictionaryBuilderTests
                 Action a = () => sut.Add("Test", GenericResult);
                 a.ShouldThrow<ArgumentException>()
                  .Message.ShouldBe("An item with the same key has already been added. Key: Test");
+            }
+        }
+
+        public class AddRange_Task : Generic
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+
+                // Act
+                sut.AddRange("Test", [GenericTask]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+                sut.Add("Test0", GenericTask);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [GenericTask]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Func : Generic
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+
+                // Act
+                sut.AddRange("Test", [GenericFunc]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+                sut.Add("Test0", GenericFunc);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [GenericFunc]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Result : Generic
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+
+                // Act
+                sut.AddRange("Test", [GenericResult]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+                sut.Add("Test0", GenericResult);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", [GenericResult]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
             }
         }
 

--- a/src/CrossCutting.Common/CrossCutting.Common.csproj
+++ b/src/CrossCutting.Common/CrossCutting.Common.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Common</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.23.0</Version>
-    <PackageVersion>3.23.0</PackageVersion>
+    <Version>3.24.0</Version>
+    <PackageVersion>3.24.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/CrossCutting.Common/Results/AsyncResultDictionaryBuilder.cs
+++ b/src/CrossCutting.Common/Results/AsyncResultDictionaryBuilder.cs
@@ -52,6 +52,90 @@ public class AsyncResultDictionaryBuilder
         return this;
     }
 
+    public AsyncResultDictionaryBuilder AddRange(string nameFormatString, IEnumerable<Task<Result>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder AddRange<T>(string nameFormatString, IEnumerable<Task<Result<T>>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder AddRange(string nameFormatString, IEnumerable<Func<Result>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder AddRange<T>(string nameFormatString, IEnumerable<Func<Result<T>>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder AddRange(string nameFormatString, IEnumerable<Result> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder AddRange<T>(string nameFormatString, IEnumerable<Result<T>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
     public IReadOnlyDictionary<string, Task<Result>> BuildDeferred()
     {
         var results = new Dictionary<string, Task<Result>>();
@@ -144,6 +228,48 @@ public class AsyncResultDictionaryBuilder<T>
         value = ArgumentGuard.IsNotNull(value, nameof(value));
 
         _resultset.Add(name, Task.FromResult(value));
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder<T> AddRange(string nameFormatString, IEnumerable<Task<Result<T>>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder<T> AddRange(string nameFormatString, IEnumerable<Func<Result<T>>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder<T> AddRange(string nameFormatString, IEnumerable<Result<T>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
         return this;
     }
 

--- a/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
+++ b/src/CrossCutting.Data.Abstractions.Tests/CrossCutting.Data.Abstractions.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
+++ b/src/CrossCutting.Data.Core.Tests/CrossCutting.Data.Core.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
+++ b/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Data.Core</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>5.0.18</Version>
-    <PackageVersion>5.0.18</PackageVersion>
+    <Version>5.0.19</Version>
+    <PackageVersion>5.0.19</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
+++ b/src/CrossCutting.Data.Sql.Tests/CrossCutting.Data.Sql.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/CrossCutting.Data.Sql/CrossCutting.Data.Sql.csproj
+++ b/src/CrossCutting.Data.Sql/CrossCutting.Data.Sql.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Data.Sql</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>6.0.18</Version>
-    <PackageVersion>6.0.18</PackageVersion>
+    <Version>6.0.19</Version>
+    <PackageVersion>6.0.19</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
+++ b/src/CrossCutting.DataTableDumper.Tests/CrossCutting.DataTableDumper.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
+++ b/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.DataTableDumper</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.23.0</Version>
-    <PackageVersion>3.23.0</PackageVersion>
+    <Version>3.24.0</Version>
+    <PackageVersion>3.24.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.ProcessingPipeline.Tests/CrossCutting.ProcessingPipeline.Tests.csproj
+++ b/src/CrossCutting.ProcessingPipeline.Tests/CrossCutting.ProcessingPipeline.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
+++ b/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.ProcessingPipeline</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>9.0.8</Version>
-    <PackageVersion>9.0.8</PackageVersion>
+    <Version>9.0.9</Version>
+    <PackageVersion>9.0.9</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.Aggregators.Tests/CrossCutting.Utilities.Aggregators.Tests.csproj
+++ b/src/CrossCutting.Utilities.Aggregators.Tests/CrossCutting.Utilities.Aggregators.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/CrossCutting.Utilities.Aggregators/CrossCutting.Utilities.Aggregators.csproj
+++ b/src/CrossCutting.Utilities.Aggregators/CrossCutting.Utilities.Aggregators.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Aggregators</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.23.0</Version>
-    <PackageVersion>3.23.0</PackageVersion>
+    <Version>3.24.0</Version>
+    <PackageVersion>3.24.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.ExpressionEvaluator.CodeGeneration/CrossCutting.Utilities.ExpressionEvaluator.CodeGeneration.csproj
+++ b/src/CrossCutting.Utilities.ExpressionEvaluator.CodeGeneration/CrossCutting.Utilities.ExpressionEvaluator.CodeGeneration.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.21.7" />
-    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="2.0.13" />
+    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="2.0.14" />
   </ItemGroup>
 
 </Project>

--- a/src/CrossCutting.Utilities.ExpressionEvaluator.Tests/CrossCutting.Utilities.ExpressionEvaluator.Tests.csproj
+++ b/src/CrossCutting.Utilities.ExpressionEvaluator.Tests/CrossCutting.Utilities.ExpressionEvaluator.Tests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/CrossCutting.Utilities.ExpressionEvaluator.Tests/Extensions/AsyncResultDictionaryBuilderExtensionsTests.cs
+++ b/src/CrossCutting.Utilities.ExpressionEvaluator.Tests/Extensions/AsyncResultDictionaryBuilderExtensionsTests.cs
@@ -57,7 +57,7 @@ public class AsyncResultDictionaryBuilderExtensionsTests : TestBase
         var dict = await result.Build();
         dict.Count.ShouldBe(1);
         dict.First().Key.ShouldBe("MyName");
-        var value = dict.First().Value();
+        var value = dict.First().Value;
         value.Status.ShouldBe(ResultStatus.Ok);
         value.GetValue().ShouldBe(1);
     }

--- a/src/CrossCutting.Utilities.ExpressionEvaluator/CrossCutting.Utilities.ExpressionEvaluator.csproj
+++ b/src/CrossCutting.Utilities.ExpressionEvaluator/CrossCutting.Utilities.ExpressionEvaluator.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.ExpressionEvaluator</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>2.0.0</Version>
-    <PackageVersion>2.0.0</PackageVersion>
+    <Version>2.0.1</Version>
+    <PackageVersion>2.0.1</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper.Tests/CrossCutting.Utilities.ObjectDumper.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/CrossCutting.Utilities.ObjectDumper/CrossCutting.Utilities.ObjectDumper.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper/CrossCutting.Utilities.ObjectDumper.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Utilities.ObjectDumper</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.23.0</Version>
-    <PackageVersion>3.23.0</PackageVersion>
+    <Version>3.24.0</Version>
+    <PackageVersion>3.24.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.Operators/CrossCutting.Utilities.Operators.csproj
+++ b/src/CrossCutting.Utilities.Operators/CrossCutting.Utilities.Operators.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Operators</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.23.0</Version>
-    <PackageVersion>3.23.0</PackageVersion>
+    <Version>3.24.0</Version>
+    <PackageVersion>3.24.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
+++ b/src/CrossCutting.Utilities.Parsers.Tests/CrossCutting.Utilities.Parsers.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
+++ b/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Parsers</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>10.1.3</Version>
-    <PackageVersion>10.1.3</PackageVersion>
+    <Version>10.1.4</Version>
+    <PackageVersion>10.1.4</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
+++ b/src/System.Data.Stub.Tests/System.Data.Stub.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
- Changed AsyncResultDictionaryBuilder, so you can choose between Func<Result<T>> and Result<T>. Why use Func<Result<T>> when it's already evaluated?
- Added AddRange methods to AsyncResultDictionaryBuilder