### PR TITLE
Small improvements

### DIFF
--- a/src/CrossCutting.Common.Tests/Extensions/AsyncResultDictionaryExtensionsTests.cs
+++ b/src/CrossCutting.Common.Tests/Extensions/AsyncResultDictionaryExtensionsTests.cs
@@ -1,0 +1,53 @@
+﻿namespace CrossCutting.Common.Tests.Extensions;
+
+public class AsyncResultDictionaryExtensionsTests
+{
+    public class TryGetValueAsync : AsyncResultDictionaryExtensionsTests
+    {
+        [Fact]
+        public async Task Returns_Success_When_Key_Is_Found_And_Type_Is_Correct()
+        {
+            // Arrange
+            var sut = new AsyncResultDictionaryBuilder<object?>()
+                .Add("Key", Result.Success<object?>("Some value"))
+                .BuildDeferred();
+
+            // Act
+            var result = await sut.TryGetValueAsync<string>("Key");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Ok);
+            result.Value.ShouldBe("Some value");
+        }
+
+        [Fact]
+        public async Task Returns_Invalid_When_Key_Is_Found_But_Type_Is_Not_Correct()
+        {
+            // Arrange
+            var sut = new AsyncResultDictionaryBuilder<object?>()
+                .Add("Key", Result.Success<object?>("Some value"))
+                .BuildDeferred();
+
+            // Act
+            var result = await sut.TryGetValueAsync<int>("Key");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.Invalid);
+        }
+
+        [Fact]
+        public async Task Returns_NotFound_When_Key_Is_Not_Found()
+        {
+            // Arrange
+            var sut = new AsyncResultDictionaryBuilder<object?>()
+                .Add("Key", Result.Success<object?>("Some value"))
+                .BuildDeferred();
+
+            // Act
+            var result = await sut.TryGetValueAsync<int>("WrongKey");
+
+            // Assert
+            result.Status.ShouldBe(ResultStatus.NotFound);
+        }
+    }
+}

--- a/src/CrossCutting.Common.Tests/Extensions/ResultDictionaryExtensionsTests.cs
+++ b/src/CrossCutting.Common.Tests/Extensions/ResultDictionaryExtensionsTests.cs
@@ -557,7 +557,7 @@ public class ResultDictionaryExtensionsTests
                 .Build();
 
             // Act
-            var result = sut.GetValue<string>("Step1");
+            var result = sut.GetValue("Step1");
 
             // Assert
             result.ShouldBe("My value");
@@ -678,7 +678,7 @@ public class ResultDictionaryExtensionsTests
                 .Build();
 
             // Act
-            var result = sut.TryGetValue<string>("Step1");
+            var result = sut.TryGetValue("Step1");
 
             // Assert
             result.ShouldBe("My value");

--- a/src/CrossCutting.Common.Tests/Extensions/ResultStatusExtensionsTests.cs
+++ b/src/CrossCutting.Common.Tests/Extensions/ResultStatusExtensionsTests.cs
@@ -24,7 +24,7 @@ public class ResultStatusExtensionsTests
         var status = ResultStatus.BadGateway;
 
         // Act
-        var result = status.ToTypedResult<string>("Value", "there is a very bad gateway here", exception: new InvalidOperationException("error"));
+        var result = status.ToTypedResult("Value", "there is a very bad gateway here", exception: new InvalidOperationException("error"));
 
         // Assert
         result.Status.ShouldBe(status);

--- a/src/CrossCutting.Common.Tests/Results/AsyncResultDictionaryBuilderTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/AsyncResultDictionaryBuilderTests.cs
@@ -203,6 +203,36 @@ public class AsyncResultDictionaryBuilderTests
             }
         }
 
+        public class Add_Typed_Value : NonGeneric
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+
+                // Act
+                sut.Add("Test", "GenericResult");
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test", GenericResult);
+
+                // Act & Assert
+                Action a = () => sut.Add("Test", "GenericResult");
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test");
+            }
+        }
         public class AddRange_Untyped_Task : NonGeneric
         {
             [Fact]
@@ -384,6 +414,37 @@ public class AsyncResultDictionaryBuilderTests
 
                 // Act & Assert
                 Action a = () => sut.AddRange("Test{0}", [GenericResult]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Typed_Value : NonGeneric
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+
+                // Act
+                sut.AddRange("Test", ["Some value"]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder();
+                sut.Add("Test0", GenericResult);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", ["Some value"]);
                 a.ShouldThrow<ArgumentException>()
                  .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
             }

--- a/src/CrossCutting.Common.Tests/Results/AsyncResultDictionaryBuilderTests.cs
+++ b/src/CrossCutting.Common.Tests/Results/AsyncResultDictionaryBuilderTests.cs
@@ -428,7 +428,7 @@ public class AsyncResultDictionaryBuilderTests
                 var sut = new AsyncResultDictionaryBuilder();
 
                 // Act
-                sut.AddRange("Test", ["Some value"]);
+                sut.AddRange("Test", ["some value"]);
 
                 // Assert
                 var dictionary = await sut.Build();
@@ -444,7 +444,7 @@ public class AsyncResultDictionaryBuilderTests
                 sut.Add("Test0", GenericResult);
 
                 // Act & Assert
-                Action a = () => sut.AddRange("Test{0}", ["Some value"]);
+                Action a = () => sut.AddRange("Test{0}", ["some value"]);
                 a.ShouldThrow<ArgumentException>()
                  .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
             }
@@ -668,6 +668,37 @@ public class AsyncResultDictionaryBuilderTests
             }
         }
 
+        public class Add_Value : Generic
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+
+                // Act
+                sut.Add("Test", "some value");
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+                sut.Add("Test", GenericResult);
+
+                // Act & Assert
+                Action a = () => sut.Add("Test", "some value");
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test");
+            }
+        }
+
         public class AddRange_Task : Generic
         {
             [Fact]
@@ -756,6 +787,37 @@ public class AsyncResultDictionaryBuilderTests
 
                 // Act & Assert
                 Action a = () => sut.AddRange("Test{0}", [GenericResult]);
+                a.ShouldThrow<ArgumentException>()
+                 .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
+            }
+        }
+
+        public class AddRange_Value : Generic
+        {
+            [Fact]
+            public async Task Adds_Result_Task_Successfully()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+
+                // Act
+                sut.AddRange("Test", ["some value"]);
+
+                // Assert
+                var dictionary = await sut.Build();
+                dictionary.Count.ShouldBe(1);
+                dictionary.First().Key.ShouldBe("Test");
+            }
+
+            [Fact]
+            public void Throws_On_Duplicate_Key()
+            {
+                // Arrange
+                var sut = new AsyncResultDictionaryBuilder<string>();
+                sut.Add("Test0", GenericResult);
+
+                // Act & Assert
+                Action a = () => sut.AddRange("Test{0}", ["some value"]);
                 a.ShouldThrow<ArgumentException>()
                  .Message.ShouldBe("An item with the same key has already been added. Key: Test0");
             }

--- a/src/CrossCutting.Common/CrossCutting.Common.csproj
+++ b/src/CrossCutting.Common/CrossCutting.Common.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Common</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.24.0</Version>
-    <PackageVersion>3.24.0</PackageVersion>
+    <Version>3.25.0</Version>
+    <PackageVersion>3.25.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/CrossCutting.Common/Extensions/AsyncResultDictionaryExtensions.cs
+++ b/src/CrossCutting.Common/Extensions/AsyncResultDictionaryExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace CrossCutting.Common.Extensions;
+
+public static class AsyncResultDictionaryExtensions
+{
+    public static async Task<Result<T>> TryGetValueAsync<T>(this IReadOnlyDictionary<string, Task<Result<object?>>> instance, string resultKey)
+        => instance.TryGetValue(resultKey, out var settingsResult)
+            ? (await settingsResult.ConfigureAwait(false))
+                .TryCastAllowNull<T>()
+            : Result.NotFound<T>($"{resultKey} was not found in state");
+}

--- a/src/CrossCutting.Common/Extensions/ResultDictionaryExtensions.cs
+++ b/src/CrossCutting.Common/Extensions/ResultDictionaryExtensions.cs
@@ -34,6 +34,19 @@ public static class ResultDictionaryExtensions
         };
     }
 
+    public static Result<T> OnSuccess<T>(this IReadOnlyDictionary<string, Result<T>> resultDictionary, Func<IReadOnlyDictionary<string, Result<T>>, T> successDelegate)
+    {
+        successDelegate = ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
+
+        var error = resultDictionary.GetError();
+
+        return error switch
+        {
+            not null => error,
+            _ => Result.Success(successDelegate(resultDictionary))
+        };
+    }
+
     public static Result OnSuccess(this IReadOnlyDictionary<string, Result> resultDictionary, Func<IReadOnlyDictionary<string, Result>, Result> successDelegate)
     {
         successDelegate = ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
@@ -57,6 +70,19 @@ public static class ResultDictionaryExtensions
         {
             not null => Result.FromExistingResult<T>(error),
             _ => successDelegate(resultDictionary)
+        };
+    }
+
+    public static Result<T> OnSuccess<T>(this IReadOnlyDictionary<string, Result> resultDictionary, Func<IReadOnlyDictionary<string, Result>, T> successDelegate)
+    {
+        successDelegate = ArgumentGuard.IsNotNull(successDelegate, nameof(successDelegate));
+
+        var error = resultDictionary.GetError();
+
+        return error switch
+        {
+            not null => Result.FromExistingResult<T>(error),
+            _ => Result.Success(successDelegate(resultDictionary))
         };
     }
 

--- a/src/CrossCutting.Common/Results/AsyncResultDictionaryBuilder.cs
+++ b/src/CrossCutting.Common/Results/AsyncResultDictionaryBuilder.cs
@@ -253,6 +253,14 @@ public class AsyncResultDictionaryBuilder<T>
         return this;
     }
 
+    public AsyncResultDictionaryBuilder<T> Add(string name, T value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        _resultset.Add(name, Task.FromResult(Result.Success(value)));
+        return this;
+    }
+
     public AsyncResultDictionaryBuilder<T> AddRange(string nameFormatString, IEnumerable<Task<Result<T>>> value)
     {
         value = ArgumentGuard.IsNotNull(value, nameof(value));
@@ -282,6 +290,20 @@ public class AsyncResultDictionaryBuilder<T>
     }
 
     public AsyncResultDictionaryBuilder<T> AddRange(string nameFormatString, IEnumerable<Result<T>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder<T> AddRange(string nameFormatString, IEnumerable<T> value)
     {
         value = ArgumentGuard.IsNotNull(value, nameof(value));
 

--- a/src/CrossCutting.Common/Results/AsyncResultDictionaryBuilder.cs
+++ b/src/CrossCutting.Common/Results/AsyncResultDictionaryBuilder.cs
@@ -52,6 +52,14 @@ public class AsyncResultDictionaryBuilder
         return this;
     }
 
+    public AsyncResultDictionaryBuilder Add<T>(string name, T value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        _resultset.Add(name, Task.Run<Result>(() => Result.Success(value)));
+        return this;
+    }
+
     public AsyncResultDictionaryBuilder AddRange(string nameFormatString, IEnumerable<Task<Result>> value)
     {
         value = ArgumentGuard.IsNotNull(value, nameof(value));
@@ -123,6 +131,20 @@ public class AsyncResultDictionaryBuilder
     }
 
     public AsyncResultDictionaryBuilder AddRange<T>(string nameFormatString, IEnumerable<Result<T>> value)
+    {
+        value = ArgumentGuard.IsNotNull(value, nameof(value));
+
+        var counter = 0;
+        foreach (var item in value)
+        {
+            var name = string.Format(nameFormatString, counter);
+            Add(name, item);
+        }
+
+        return this;
+    }
+
+    public AsyncResultDictionaryBuilder AddRange<T>(string nameFormatString, IEnumerable<T> value)
     {
         value = ArgumentGuard.IsNotNull(value, nameof(value));
 

--- a/src/CrossCutting.Common/Results/Result.cs
+++ b/src/CrossCutting.Common/Results/Result.cs
@@ -40,7 +40,7 @@ public record Result<T> : Result
             return FromExistingResult<TTarget>(this);
         }
 
-        return new(transformDelegate(Value!), Status, ErrorMessage, ValidationErrors, InnerResults, null);
+        return new(transformDelegate(Value), Status, ErrorMessage, ValidationErrors, InnerResults, null);
     }
 
     public Result<TTarget> Transform<TTarget>(Func<T, Result<TTarget>> transformDelegate)
@@ -52,7 +52,7 @@ public record Result<T> : Result
             return FromExistingResult<TTarget>(this);
         }
 
-        return transformDelegate(Value!);
+        return transformDelegate(Value);
     }
 
     public Result Transform(Func<T, Result> transformDelegate)
@@ -64,7 +64,7 @@ public record Result<T> : Result
             return this;
         }
 
-        return transformDelegate(Value!);
+        return transformDelegate(Value);
     }
 
     public Result<T> Either(Func<Result<T>, Result<T>> errorDelegate)

--- a/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
+++ b/src/CrossCutting.Data.Core/CrossCutting.Data.Core.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Data.Core</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>5.0.19</Version>
-    <PackageVersion>5.0.19</PackageVersion>
+    <Version>5.0.20</Version>
+    <PackageVersion>5.0.20</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Data.Sql/CrossCutting.Data.Sql.csproj
+++ b/src/CrossCutting.Data.Sql/CrossCutting.Data.Sql.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Data.Sql</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>6.0.19</Version>
-    <PackageVersion>6.0.19</PackageVersion>
+    <Version>6.0.20</Version>
+    <PackageVersion>6.0.20</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
+++ b/src/CrossCutting.DataTableDumper/CrossCutting.DataTableDumper.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.DataTableDumper</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.24.0</Version>
-    <PackageVersion>3.24.0</PackageVersion>
+    <Version>3.25.0</Version>
+    <PackageVersion>3.25.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
+++ b/src/CrossCutting.ProcessingPipeline/CrossCutting.ProcessingPipeline.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.ProcessingPipeline</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>9.0.9</Version>
-    <PackageVersion>9.0.9</PackageVersion>
+    <Version>9.0.10</Version>
+    <PackageVersion>9.0.10</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.Aggregators/CrossCutting.Utilities.Aggregators.csproj
+++ b/src/CrossCutting.Utilities.Aggregators/CrossCutting.Utilities.Aggregators.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Aggregators</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.24.0</Version>
-    <PackageVersion>3.24.0</PackageVersion>
+    <Version>3.25.0</Version>
+    <PackageVersion>3.25.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.ExpressionEvaluator.Tests/IntegrationTests.cs
+++ b/src/CrossCutting.Utilities.ExpressionEvaluator.Tests/IntegrationTests.cs
@@ -779,6 +779,30 @@ public sealed class IntegrationTests : TestBase, IDisposable
     }
 
     [Fact]
+    public async Task Can_Perform_Logic_In_Property_Like_We_Do_In_ClassFramework_Untyped_On_Error()
+    {
+        // Arrange
+        var state = new AsyncResultDictionaryBuilder();
+        var functionParser = Substitute.For<IFunctionParser>();
+        functionParser
+            .Parse(Arg.Any<ExpressionEvaluatorContext>())
+            .Returns(Result.Success(new FunctionCallBuilder().WithName("Dummy").WithMemberType(MemberType.Function).Build()));
+
+        var context = new FunctionCallContext(new DotExpressionComponentState(CreateContext("Dummy()", state), functionParser, Result.Success<object?>("Dummy"), "Dummy", typeof(string)) { Value = "hello" });
+
+        // Act
+        var result = (await new AsyncResultDictionaryBuilder()
+            .Add("instance", context.GetInstanceValueResult<string>())
+            .Add("error", Result.Error("Kaboom"))
+            .Build())
+            .OnSuccess(results => results.GetValue<string>("instance"));
+
+        // Assert
+        result.Status.ShouldBe(ResultStatus.Error);
+        result.ErrorMessage.ShouldBe("Kaboom");
+    }
+
+    [Fact]
     public async Task Can_Perform_Logic_In_Property_Like_We_Do_In_ClassFramework_Typed()
     {
         // Arrange
@@ -799,6 +823,30 @@ public sealed class IntegrationTests : TestBase, IDisposable
         // Assert
         result.Status.ShouldBe(ResultStatus.Ok);
         result.Value.ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task Can_Perform_Logic_In_Property_Like_We_Do_In_ClassFramework_Typed_On_Error()
+    {
+        // Arrange
+        var state = new AsyncResultDictionaryBuilder();
+        var functionParser = Substitute.For<IFunctionParser>();
+        functionParser
+            .Parse(Arg.Any<ExpressionEvaluatorContext>())
+            .Returns(Result.Success(new FunctionCallBuilder().WithName("Dummy").WithMemberType(MemberType.Function).Build()));
+
+        var context = new FunctionCallContext(new DotExpressionComponentState(CreateContext("Dummy()", state), functionParser, Result.Success<object?>("Dummy"), "Dummy", typeof(string)) { Value = "hello" });
+
+        // Act
+        var result = (await new AsyncResultDictionaryBuilder<object?>()
+            .Add("instance", context.GetInstanceValueResult<string>())
+            .Add("error", Result.Error<object?>("Kaboom"))
+            .Build())
+            .OnSuccess(results => results.GetValue("instance"));
+
+        // Assert
+        result.Status.ShouldBe(ResultStatus.Error);
+        result.ErrorMessage.ShouldBe("Kaboom");
     }
 
     [Fact]

--- a/src/CrossCutting.Utilities.ExpressionEvaluator.Tests/IntegrationTests.cs
+++ b/src/CrossCutting.Utilities.ExpressionEvaluator.Tests/IntegrationTests.cs
@@ -756,6 +756,52 @@ public sealed class IntegrationTests : TestBase, IDisposable
     }
 
     [Fact]
+    public async Task Can_Perform_Logic_In_Property_Like_We_Do_In_ClassFramework_Untyped()
+    {
+        // Arrange
+        var state = new AsyncResultDictionaryBuilder();
+        var functionParser = Substitute.For<IFunctionParser>();
+        functionParser
+            .Parse(Arg.Any<ExpressionEvaluatorContext>())
+            .Returns(Result.Success(new FunctionCallBuilder().WithName("Dummy").WithMemberType(MemberType.Function).Build()));
+
+        var context = new FunctionCallContext(new DotExpressionComponentState(CreateContext("Dummy()", state), functionParser, Result.Success<object?>("Dummy"), "Dummy", typeof(string)) { Value = "hello" });
+
+        // Act
+        var result = (await new AsyncResultDictionaryBuilder()
+            .Add("instance", context.GetInstanceValueResult<string>())
+            .Build())
+            .OnSuccess(results => results.GetValue<string>("instance"));
+
+        // Assert
+        result.Status.ShouldBe(ResultStatus.Ok);
+        result.Value.ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task Can_Perform_Logic_In_Property_Like_We_Do_In_ClassFramework_Typed()
+    {
+        // Arrange
+        var state = new AsyncResultDictionaryBuilder();
+        var functionParser = Substitute.For<IFunctionParser>();
+        functionParser
+            .Parse(Arg.Any<ExpressionEvaluatorContext>())
+            .Returns(Result.Success(new FunctionCallBuilder().WithName("Dummy").WithMemberType(MemberType.Function).Build()));
+
+        var context = new FunctionCallContext(new DotExpressionComponentState(CreateContext("Dummy()", state), functionParser, Result.Success<object?>("Dummy"), "Dummy", typeof(string)) { Value = "hello" });
+
+        // Act
+        var result = (await new AsyncResultDictionaryBuilder<object?>()
+            .Add("instance", context.GetInstanceValueResult<string>())
+            .Build())
+            .OnSuccess(results => results.GetValue("instance"));
+
+        // Assert
+        result.Status.ShouldBe(ResultStatus.Ok);
+        result.Value.ShouldBe("hello");
+    }
+
+    [Fact]
     public async Task Can_Parse_Binary_Operator_Expression()
     {
         // Arrange

--- a/src/CrossCutting.Utilities.ExpressionEvaluator/CrossCutting.Utilities.ExpressionEvaluator.csproj
+++ b/src/CrossCutting.Utilities.ExpressionEvaluator/CrossCutting.Utilities.ExpressionEvaluator.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.ExpressionEvaluator</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>2.0.1</Version>
-    <PackageVersion>2.0.1</PackageVersion>
+    <Version>2.0.2</Version>
+    <PackageVersion>2.0.2</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.ObjectDumper/CrossCutting.Utilities.ObjectDumper.csproj
+++ b/src/CrossCutting.Utilities.ObjectDumper/CrossCutting.Utilities.ObjectDumper.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <PackageId>pauldeen79.CrossCutting.Utilities.ObjectDumper</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.24.0</Version>
-    <PackageVersion>3.24.0</PackageVersion>
+    <Version>3.25.0</Version>
+    <PackageVersion>3.25.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.Operators/CrossCutting.Utilities.Operators.csproj
+++ b/src/CrossCutting.Utilities.Operators/CrossCutting.Utilities.Operators.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Operators</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>3.24.0</Version>
-    <PackageVersion>3.24.0</PackageVersion>
+    <Version>3.25.0</Version>
+    <PackageVersion>3.25.0</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
+++ b/src/CrossCutting.Utilities.Parsers/CrossCutting.Utilities.Parsers.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <PackageId>pauldeen79.CrossCutting.Utilities.Parsers</PackageId>
     <RepositoryUrl>https://github.com/pauldeen79/CrossCutting</RepositoryUrl>
-    <Version>10.1.4</Version>
-    <PackageVersion>10.1.4</PackageVersion>
+    <Version>10.1.5</Version>
+    <PackageVersion>10.1.5</PackageVersion>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>


### PR DESCRIPTION
Added some convenience methods for working with results and async result dictionary builders.

- Added AsyncResultDictionary.TryGetValueAssync<T> method, so you have key and type checking while getting values from your async result dictionary
- Added ResultDictionary.OnSuccess with a value instead of a Result, so you don't need to wrap Result.Success around your value
- Added overload to Add and AddRange on AsyncResultDictionaryBuilder and AsyncResultDictionaryBuilder<T> that takes an value instead of a Result/Func<Result>/Task<Result>, so you don't need to wrap Result.Success around your value